### PR TITLE
#15 : Fixed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ subprojects {
     apply plugin: 'maven-publish'
 
     group 'ru.tinkoff.qa.neptune'
-    version '0.2.1-ALPHA'
+    version '0.2.2-ALPHA'
 
     sourceCompatibility = 1.9
     targetCompatibility = 1.9

--- a/testng.integration/src/main/java/ru/tinkoff/qa/neptune/testng/integration/DefaultTestRunningListener.java
+++ b/testng.integration/src/main/java/ru/tinkoff/qa/neptune/testng/integration/DefaultTestRunningListener.java
@@ -29,6 +29,8 @@ public class DefaultTestRunningListener implements IInvokedMethodListener, ISuit
     private final List<Class<? extends Annotation>> refreshBeforeMethodsAnnotatedBy =
             new ArrayList<>(REFRESH_STRATEGY_PROPERTY.get().stream().map(RefreshEachTimeBefore::get).collect(toList()));
 
+    private final ThreadLocal<Method> previouslyRefreshed = new ThreadLocal<>();
+
     private static boolean isIgnored(Method method) {
         Class<?> declaredBy;
         Test test;
@@ -54,14 +56,17 @@ public class DefaultTestRunningListener implements IInvokedMethodListener, ISuit
             return;
         }
 
-        int methodModifiers = method.getModifiers();
-        if (!isStatic(methodModifiers) && stream(method.getAnnotations())
-                .filter(annotation -> refreshBeforeMethodsAnnotatedBy
-                        .contains(((Annotation) annotation).annotationType())).collect(toList())
-                .size() > 0) {
-            refresh(instance);
-        }
-
+        ofNullable(previouslyRefreshed.get())
+                .ifPresentOrElse(method1 -> {}, () -> {
+                    int methodModifiers = method.getModifiers();
+                    if (!isStatic(methodModifiers) && stream(method.getAnnotations())
+                            .filter(annotation -> refreshBeforeMethodsAnnotatedBy
+                                    .contains(((Annotation) annotation).annotationType())).collect(toList())
+                            .size() > 0) {
+                        refresh(instance);
+                        previouslyRefreshed.set(method);
+                    }
+                });
     }
 
     @Override
@@ -71,6 +76,10 @@ public class DefaultTestRunningListener implements IInvokedMethodListener, ISuit
         Method reflectionMethod = method.getTestMethod().getConstructorOrMethod().getMethod();
         ofNullable(testResult.getInstance()).ifPresent(o ->
                 refreshIfNecessary(o, reflectionMethod));
+
+        if (method.isTestMethod()) {
+            previouslyRefreshed.remove();
+        }
 
         ofNullable(reflectionMethod.getAnnotation(Test.class)).ifPresent(test -> {
             String name = isNotBlank(test.description()) ? test.description() : reflectionMethod.getName();

--- a/testng.integration/src/main/java/ru/tinkoff/qa/neptune/testng/integration/properties/RefreshEachTimeBefore.java
+++ b/testng.integration/src/main/java/ru/tinkoff/qa/neptune/testng/integration/properties/RefreshEachTimeBefore.java
@@ -16,7 +16,7 @@ public enum RefreshEachTimeBefore implements Supplier<Class<? extends Annotation
     /**
      * This element is used to define the strategy to invoke the
      * {@link Refreshable#refresh()} each time before
-     * any method annotated by {@link BeforeSuite} is run.
+     * the first method annotated by {@link BeforeSuite} is run.
      */
     SUITE_STARTING {
         @Override
@@ -28,7 +28,15 @@ public enum RefreshEachTimeBefore implements Supplier<Class<? extends Annotation
     /**
      * This element is used to define the strategy to invoke the
      * {@link Refreshable#refresh()} each time before
-     * any method annotated by {@link BeforeTest} is run.
+     * the first annotated by {@link BeforeTest} is run.
+     *
+     * <>p</>
+     * Rule:
+     * <>p</>
+     * {@link Refreshable#refresh()} is invoked when:
+     * <>p</>
+     * 1. {@link Refreshable#refresh()} has not been invoked before any not static
+     * {@link BeforeSuite}/{@link BeforeTest}-method.
      */
     ALL_TEST_STARTING {
         @Override
@@ -40,7 +48,19 @@ public enum RefreshEachTimeBefore implements Supplier<Class<? extends Annotation
     /**
      * This element is used to define the strategy to invoke the
      * {@link Refreshable#refresh()} each time before
-     * any method annotated by {@link BeforeClass} is run.
+     * the first {@link BeforeClass} - method of a class is run.
+     *
+     * <>p</>
+     * Rule:
+     * <>p</>
+     * {@link Refreshable#refresh()} is invoked when:
+     * <>p</>
+     * 1. {@link Refreshable#refresh()} has not been invoked before some not static
+     * {@link BeforeSuite}/{@link BeforeTest}/{@link BeforeClass}-method
+     * and any {@link Test}-method has not been started still.
+     * <>p</>
+     * 2. {@link Refreshable#refresh()} has not been invoked before some not static
+     * {@link BeforeClass}-method and any {@link Test}-method has not been started still.
      */
     CLASS_STARTING {
         @Override
@@ -52,7 +72,7 @@ public enum RefreshEachTimeBefore implements Supplier<Class<? extends Annotation
     /**
      * This element is used to define the strategy to invoke the
      * {@link Refreshable#refresh()} each time before
-     * any method annotated by {@link BeforeGroups} is run.
+     * the first {@link BeforeGroups} - method of a group is run.
      */
     GROUP_STARTING {
         @Override
@@ -64,7 +84,19 @@ public enum RefreshEachTimeBefore implements Supplier<Class<? extends Annotation
     /**
      * This element is used to define the strategy to invoke the
      * {@link Refreshable#refresh()} each time before
-     * any method annotated by {@link BeforeMethod} is run.
+     * the first method annotated by {@link BeforeMethod} is run before any test.
+     *
+     * <>p</>
+     * Rule:
+     * <>p</>
+     * {@link Refreshable#refresh()} is invoked when:
+     * <>p</>
+     * 1. {@link Refreshable#refresh()} has not been invoked before some not static
+     * {@link BeforeSuite}/{@link BeforeTest}/{@link BeforeClass}/{@link BeforeGroups}/
+     * {@link BeforeMethod}-method and any {@link Test}-method has not been started still.
+     * <>p</>
+     * 2. {@link Refreshable#refresh()} has not been invoked before some not static
+     * {@link BeforeMethod}-method and any {@link Test}-method has not been started still.
      */
     BEFORE_METHOD_STARTING {
         @Override
@@ -77,6 +109,18 @@ public enum RefreshEachTimeBefore implements Supplier<Class<? extends Annotation
      * This element is used to define the strategy to invoke the
      * {@link Refreshable#refresh()} each time before
      * any method annotated by {@link Test} is run.
+     *
+     * <>p</>
+     * Rule:
+     * <>p</>
+     * {@link Refreshable#refresh()} is invoked when:
+     * <>p</>
+     * 1. {@link Refreshable#refresh()} has not been invoked before some not static
+     * {@link BeforeSuite}/{@link BeforeTest}/{@link BeforeClass}/{@link BeforeGroups}/
+     * {@link BeforeMethod}-method and any {@link Test}-method has not been started still.
+     * <>p</>
+     * 2. {@link Refreshable#refresh()} has not been invoked before some not static
+     * {@link BeforeMethod}-method and any {@link Test}-method has not been started still.
      */
     METHOD_STARTING {
         @Override

--- a/testng.integration/src/test/java/ru/tinkoff/qa/neptune/testng/integration/test/StepClass1.java
+++ b/testng.integration/src/test/java/ru/tinkoff/qa/neptune/testng/integration/test/StepClass1.java
@@ -8,7 +8,7 @@ import ru.tinkoff.qa.neptune.core.api.cleaning.Refreshable;
 @CreateWith(provider = ProviderOfEmptyParameters.class)
 public class StepClass1 implements PerformActionStep<StepClass1>, Refreshable {
 
-    private int refreshCount;
+    private static int refreshCount;
 
     @Override
     public void refresh() {
@@ -16,7 +16,7 @@ public class StepClass1 implements PerformActionStep<StepClass1>, Refreshable {
     }
 
 
-    public int getRefreshCount() {
+    public static int getRefreshCount() {
         return refreshCount;
     }
 }

--- a/testng.integration/src/test/java/ru/tinkoff/qa/neptune/testng/integration/test/StepClass2.java
+++ b/testng.integration/src/test/java/ru/tinkoff/qa/neptune/testng/integration/test/StepClass2.java
@@ -9,8 +9,8 @@ public class StepClass2 implements GetStep<StepClass2>, PerformActionStep<StepCl
 
     private final int a;
     private final int b;
-    private int refreshCount;
-    private int stopCount;
+    private static int refreshCount;
+    private static int stopCount;
 
     public StepClass2(int a, int b) {
         this.a = a;
@@ -35,11 +35,16 @@ public class StepClass2 implements GetStep<StepClass2>, PerformActionStep<StepCl
         stopCount ++;
     }
 
-    int getRefreshCount() {
+    static int getRefreshCount() {
         return refreshCount;
     }
 
-    int getStopCount() {
+    static int getStopCount() {
         return stopCount;
+    }
+
+    static void countsToZero() {
+        refreshCount = 0;
+        stopCount = 0;
     }
 }

--- a/testng.integration/src/test/java/ru/tinkoff/qa/neptune/testng/integration/test/TestNgInstantiationTest.java
+++ b/testng.integration/src/test/java/ru/tinkoff/qa/neptune/testng/integration/test/TestNgInstantiationTest.java
@@ -1,5 +1,6 @@
 package ru.tinkoff.qa.neptune.testng.integration.test;
 
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -23,5 +24,22 @@ public class TestNgInstantiationTest extends BaseTestNgIntegrationTest {
         assertThat(getStepClass2().getB(), is(2));
         assertThat(getStepClass3(), nullValue());
         assertThat(getStepClass4(), nullValue());
+    }
+
+    @DataProvider(parallel = true)
+    public Object[][] dataProvider() {
+        return new Object[][]{
+                {1},
+                {2},
+                {3},
+                {4},
+                {5},
+        };
+    }
+
+    @Test(dataProvider = "dataProvider")
+    public void instantiationTest2(Integer integer) {
+        assertThat(getStepClass2().getA() + integer, is(1 + integer));
+        assertThat(getStepClass2().getB() + integer, is(2 + integer));
     }
 }

--- a/testng.integration/src/test/java/ru/tinkoff/qa/neptune/testng/integration/test/TestNgTestFinishingTest.java
+++ b/testng.integration/src/test/java/ru/tinkoff/qa/neptune/testng/integration/test/TestNgTestFinishingTest.java
@@ -1,5 +1,6 @@
 package ru.tinkoff.qa.neptune.testng.integration.test;
 
+import org.testng.annotations.BeforeMethod;
 import ru.tinkoff.qa.neptune.testng.integration.properties.RefreshEachTimeBefore;
 import ru.tinkoff.qa.neptune.testng.integration.test.ignored.IgnoredStubTest;
 import ru.tinkoff.qa.neptune.testng.integration.test.ignored.entries.IgnoredStubTest2;
@@ -43,27 +44,29 @@ public class TestNgTestFinishingTest {
         testNG.run();
     }
 
+    @BeforeMethod
+    public void refresh() {
+        StepClass2.countsToZero();
+    }
+
     @Test
     public void shuttingDownTest() {
         runBeforeTheChecking();
-        assertThat(TestNgInstantiationTest.testNgInstantiationTest.getStepClass2()
-                .getStopCount(), is(1));
+        assertThat(StepClass2.getStopCount(), is(1));
     }
 
     @Test
     public void whenNoRefreshingStrategyIsDefined() {
         runBeforeTheChecking();
-        assertThat(TestNgStubTest.testNgStubTest
-                .getStepClass2().getRefreshCount(), is(3));
+        assertThat(StepClass2.getRefreshCount(), is(8));
     }
 
     @Test
-    public void whenNoRefreshingStrategyIsBeforeSuite() {
+    public void whenRefreshingStrategyIsBeforeSuite() {
         TestNGRefreshStrategyProperty.REFRESH_STRATEGY_PROPERTY.accept(RefreshEachTimeBefore.SUITE_STARTING.name());
         try {
             runBeforeTheChecking();
-            assertThat(TestNgStubTest.testNgStubTest
-                    .getStepClass2().getRefreshCount(), is(2));
+            assertThat(StepClass2.getRefreshCount(), is(1));
         }
         finally {
             System.getProperties().remove(TestNGRefreshStrategyProperty.REFRESH_STRATEGY_PROPERTY.getPropertyName());
@@ -71,12 +74,11 @@ public class TestNgTestFinishingTest {
     }
 
     @Test
-    public void whenNoRefreshingStrategyIsBeforeTest() {
+    public void whenRefreshingStrategyIsBeforeTest() {
         TestNGRefreshStrategyProperty.REFRESH_STRATEGY_PROPERTY.accept(RefreshEachTimeBefore.ALL_TEST_STARTING.name());
         try {
             runBeforeTheChecking();
-            assertThat(TestNgStubTest.testNgStubTest
-                    .getStepClass2().getRefreshCount(), is(2));
+            assertThat(StepClass2.getRefreshCount(), is(1));
         }
         finally {
             System.getProperties().remove(TestNGRefreshStrategyProperty.REFRESH_STRATEGY_PROPERTY.getPropertyName());
@@ -84,12 +86,11 @@ public class TestNgTestFinishingTest {
     }
 
     @Test
-    public void whenNoRefreshingStrategyIsBeforeClass() {
+    public void whenRefreshingStrategyIsBeforeClass() {
         TestNGRefreshStrategyProperty.REFRESH_STRATEGY_PROPERTY.accept(RefreshEachTimeBefore.CLASS_STARTING.name());
         try {
             runBeforeTheChecking();
-            assertThat(TestNgStubTest.testNgStubTest
-                    .getStepClass2().getRefreshCount(), is(3));
+            assertThat(StepClass2.getRefreshCount(), is(2));
         }
         finally {
             System.getProperties().remove(TestNGRefreshStrategyProperty.REFRESH_STRATEGY_PROPERTY.getPropertyName());
@@ -97,12 +98,11 @@ public class TestNgTestFinishingTest {
     }
 
     @Test
-    public void whenNoRefreshingStrategyIsBeforeMethod() {
+    public void whenRefreshingStrategyIsBeforeMethod() {
         TestNGRefreshStrategyProperty.REFRESH_STRATEGY_PROPERTY.accept(RefreshEachTimeBefore.BEFORE_METHOD_STARTING.name());
         try {
             runBeforeTheChecking();
-            assertThat(TestNgStubTest.testNgStubTest
-                    .getStepClass2().getRefreshCount(), is(7));
+            assertThat(StepClass2.getRefreshCount(), is(9));
         }
         finally {
             System.getProperties().remove(TestNGRefreshStrategyProperty.REFRESH_STRATEGY_PROPERTY.getPropertyName());
@@ -110,13 +110,12 @@ public class TestNgTestFinishingTest {
     }
 
     @Test
-    public void whenNoRefreshingStrategyIsCombined() {
+    public void whenRefreshingStrategyIsCombined() {
         TestNGRefreshStrategyProperty.REFRESH_STRATEGY_PROPERTY.accept(String.join(",", stream(RefreshEachTimeBefore.values())
                 .map(Enum::name).collect(toList())));
         try {
             runBeforeTheChecking();
-            assertThat(TestNgStubTest.testNgStubTest
-                    .getStepClass2().getRefreshCount(), is(17));
+            assertThat(StepClass2.getRefreshCount(), is(9));
         }
         finally {
             System.getProperties().remove(TestNGRefreshStrategyProperty.REFRESH_STRATEGY_PROPERTY.getPropertyName());


### PR DESCRIPTION
#15 

The excessive invoking of `refresh()` is excluded. Also now it is following the hierarchy of invocation of 
`@BeforeSuite`/`@BeforeTest`/`@BeforeClass`/`@BeforeMethod`/`@Test`

**Details:**
- Improved `DefaultTestRunningListener`
- unit tests were changed