### PR TITLE
Re-design of PersistableObject equals method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    globalVersion = '0.3.10-ALPHA'
+    globalVersion = '0.3.9-ALPHA'
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    globalVersion = '0.3.9-ALPHA'
+    globalVersion = '0.3.11-ALPHA'
 }
 
 subprojects {

--- a/data.base.api/src/main/java/ru/tinkoff/qa/neptune/data/base/api/CompositeKey.java
+++ b/data.base.api/src/main/java/ru/tinkoff/qa/neptune/data/base/api/CompositeKey.java
@@ -8,7 +8,6 @@ import java.util.stream.Collectors;
 import static java.lang.String.format;
 import static java.lang.reflect.Modifier.isStatic;
 import static java.util.Arrays.stream;
-import static java.util.Optional.ofNullable;
 
 /**
  * This class is designed to implement classes of composite key objects.
@@ -27,7 +26,7 @@ import static java.util.Optional.ofNullable;
  *            }'}
  * </p>
  */
-public abstract class CompositeKey implements Serializable {
+public abstract class CompositeKey extends OrmObject implements Serializable {
 
     @Override
     public int hashCode() {
@@ -53,55 +52,6 @@ public abstract class CompositeKey implements Serializable {
         }
 
         return result;
-    }
-
-    private boolean equalsByFields(Object obj) {
-        Class<?> clazz = this.getClass();
-        while (!clazz.equals(Object.class)) {
-            List<Field> fields = stream(clazz.getDeclaredFields()).filter(field -> !isStatic(field.getModifiers()))
-                    .collect(Collectors.toList());
-            for (Field f: fields) {
-                f.setAccessible(true);
-
-                try {
-                    Object v1 = f.get(this);
-                    Object v2 = f.get(obj);
-
-                    if (v1 == null && v2 == null) {
-                        continue;
-                    }
-
-                    if ((v1 != null && v2 == null) || (v1 == null && v2 != null)) {
-                        return false;
-                    }
-
-                    if (v1.equals(v2)) {
-                        continue;
-                    }
-
-                    return false;
-                } catch (IllegalAccessException e) {
-                    throw new RuntimeException(e.getMessage(), e);
-                }
-            }
-            clazz = clazz.getSuperclass();
-        }
-
-        return true;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        CompositeKey toCheck = this;
-        return ofNullable(obj)
-                .map(o -> {
-                    if (toCheck == o) {
-                        return true;
-                    }
-                    return toCheck.getClass().equals(obj.getClass()) &&
-                            toCheck.equalsByFields(obj);
-                })
-                .orElse(false);
     }
 
     @Override

--- a/data.base.api/src/main/java/ru/tinkoff/qa/neptune/data/base/api/OrmObject.java
+++ b/data.base.api/src/main/java/ru/tinkoff/qa/neptune/data/base/api/OrmObject.java
@@ -9,9 +9,6 @@ import static java.util.Arrays.stream;
 import static java.util.Optional.ofNullable;
 
 class OrmObject {
-
-    private static final String ORG_DATANUCLEUS = "org.datanucleus";
-
     private boolean equalsByFields(Object obj) {
         Class<?> clazz = this.getClass();
         while (!clazz.equals(Object.class)) {
@@ -19,12 +16,6 @@ class OrmObject {
                     .collect(Collectors.toList());
             for (Field f: fields) {
                 f.setAccessible(true);
-
-                Class<?> type = f.getType();
-                if (!type.isPrimitive() && type.getPackage().getName().startsWith(ORG_DATANUCLEUS)) {
-                    continue;
-                }
-
                 try {
                     Object v1 = f.get(this);
                     Object v2 = f.get(obj);

--- a/data.base.api/src/main/java/ru/tinkoff/qa/neptune/data/base/api/OrmObject.java
+++ b/data.base.api/src/main/java/ru/tinkoff/qa/neptune/data/base/api/OrmObject.java
@@ -1,0 +1,68 @@
+package ru.tinkoff.qa.neptune.data.base.api;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.lang.reflect.Modifier.isStatic;
+import static java.util.Arrays.stream;
+import static java.util.Optional.ofNullable;
+
+class OrmObject {
+
+    private static final String ORG_DATANUCLEUS = "org.datanucleus";
+
+    private boolean equalsByFields(Object obj) {
+        Class<?> clazz = this.getClass();
+        while (!clazz.equals(Object.class)) {
+            List<Field> fields = stream(clazz.getDeclaredFields()).filter(field -> !isStatic(field.getModifiers()))
+                    .collect(Collectors.toList());
+            for (Field f: fields) {
+                f.setAccessible(true);
+
+                Class<?> type = f.getType();
+                if (!type.isPrimitive() && type.getPackage().getName().startsWith(ORG_DATANUCLEUS)) {
+                    continue;
+                }
+
+                try {
+                    Object v1 = f.get(this);
+                    Object v2 = f.get(obj);
+
+                    if (v1 == null && v2 == null) {
+                        continue;
+                    }
+
+                    if ((v1 != null && v2 == null) || (v1 == null && v2 != null)) {
+                        return false;
+                    }
+
+                    if (v1.equals(v2)) {
+                        continue;
+                    }
+
+                    return false;
+                } catch (IllegalAccessException e) {
+                    throw new RuntimeException(e.getMessage(), e);
+                }
+            }
+            clazz = clazz.getSuperclass();
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        OrmObject toCheck = this;
+        return ofNullable(obj)
+                .map(o -> {
+                    if (toCheck == o) {
+                        return true;
+                    }
+                    return toCheck.getClass().equals(obj.getClass()) &&
+                            toCheck.equalsByFields(obj);
+                })
+                .orElse(false);
+    }
+}

--- a/data.base.api/src/main/java/ru/tinkoff/qa/neptune/data/base/api/PersistableObject.java
+++ b/data.base.api/src/main/java/ru/tinkoff/qa/neptune/data/base/api/PersistableObject.java
@@ -5,7 +5,7 @@ import com.google.gson.Gson;
 /**
  * This abstract class is designed to mark persistable classes.
  */
-public abstract class PersistableObject implements Cloneable {
+public abstract class PersistableObject extends OrmObject implements Cloneable {
 
     @Override
     public String toString() {

--- a/data.base.api/src/main/java/ru/tinkoff/qa/neptune/data/base/api/PersistableObject.java
+++ b/data.base.api/src/main/java/ru/tinkoff/qa/neptune/data/base/api/PersistableObject.java
@@ -1,6 +1,7 @@
 package ru.tinkoff.qa.neptune.data.base.api;
 
 import com.google.gson.Gson;
+import org.datanucleus.enhancement.Persistable;
 
 /**
  * This abstract class is designed to mark persistable classes.
@@ -18,5 +19,34 @@ public abstract class PersistableObject extends OrmObject implements Cloneable {
         } catch (CloneNotSupportedException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+
+        Class<?> otherClass = obj.getClass();
+        if (!PersistableObject.class.isAssignableFrom(otherClass)) {
+            return false;
+        }
+
+        Class<?> thisClass  = this.getClass();
+
+        if (!thisClass.equals(otherClass)) {
+            return false;
+        }
+
+        if (!Persistable.class.isAssignableFrom(thisClass) && !Persistable.class.isAssignableFrom(otherClass)) {
+            return super.equals(obj);
+        }
+
+        if ((!Persistable.class.isAssignableFrom(thisClass) && Persistable.class.isAssignableFrom(otherClass)) ||
+                (Persistable.class.isAssignableFrom(thisClass) && !Persistable.class.isAssignableFrom(otherClass))) {
+            return false;
+        }
+
+        return ((Persistable) this).dnGetObjectId().equals(((Persistable) obj).dnGetObjectId());
     }
 }

--- a/data.base.api/src/test/java/ru/tinkoff/qa/neptune/data/base/test/persistable/object/EqualityObjectTest.java
+++ b/data.base.api/src/test/java/ru/tinkoff/qa/neptune/data/base/test/persistable/object/EqualityObjectTest.java
@@ -1,0 +1,83 @@
+package ru.tinkoff.qa.neptune.data.base.test.persistable.object;
+
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class EqualityObjectTest {
+
+    @Test //compare object with null-valued fields and null
+    public void checkEqualToNull() {
+        assertThat(new PersistableObjectOne().equals(null), is(false));
+    }
+
+    @Test //compare object with null-valued fields and null
+    public void checkEqualityToPersistableOfDifferentClasses() {
+        assertThat(new PersistableObjectOne().equals(new PersistableObjectTwo()), is(false));
+        assertThat(new PersistableObjectTwo().equals(new PersistableObjectOne()), is(false));
+        assertThat(new PersistableObjectTwo().equals(new PersistableObjectThree()), is(false));
+        assertThat(new PersistableObjectTwo().equals(new UnpersistableObject()), is(false));
+    }
+
+    @Test
+    public void checkEqualityToEmptyPersistableOfSameClass() {
+        assertThat(new PersistableObjectOne().equals(new PersistableObjectOne()), is(true));
+    }
+
+    @Test
+    public void checkEqualityToPersistableOfSameClassFilledByDifferentValues() {
+        assertThat(new PersistableObjectOne().setBooleanField(true).setIntField(4).setObjectListField(List.of(1))
+                        .equals(new PersistableObjectOne().setBooleanField(false).setIntField(5).setObjectListField(List.of(1, 2))),
+                is(false));
+    }
+
+    @Test
+    public void checkEqualityToPersistableOfSameClassFilledBySameValues() {
+        assertThat(new PersistableObjectOne().setBooleanField(true).setIntField(4).setObjectListField(List.of(1))
+                        .equals(new PersistableObjectOne().setBooleanField(true).setIntField(4).setObjectListField(List.of(1))),
+                is(true));
+    }
+
+    @Test
+    public void checkEqualityToPersistableOfAssignableClassesFilledBySameValues() {
+        assertThat(new PersistableObjectOne().setBooleanField(true).setIntField(4).setObjectListField(List.of(1))
+                        .equals(new PersistableObjectTwo().setLongField(100)
+                                .setCharField('a')
+                                .setBooleanField(true)
+                                .setIntField(4)
+                                .setObjectListField(List.of(1))),
+                is(false));
+    }
+
+    @Test
+    public void checkEqualityToPersistableOfNotAssignableClassesFilledBySameValues() {
+        assertThat(new PersistableObjectTwo().setLongField(100)
+                .setCharField('a')
+                .setBooleanField(true)
+                .setIntField(4)
+                .setObjectListField(List.of(1)).equals(new PersistableObjectThree().setLongField(100)
+                                .setCharField('a')
+                                .setBooleanField(true)
+                                .setIntField(4)
+                                .setObjectListField(List.of(1))),
+                is(false));
+    }
+
+    @Test
+    public void checkEqualityToNotPersistableFilledBySameValues() {
+        assertThat(new PersistableObjectThree().setLongField(100)
+                        .setCharField('a')
+                        .setBooleanField(true)
+                        .setIntField(4)
+                        .setObjectListField(List.of(1)).equals(new UnpersistableObject().setLongField(100)
+                                .setCharField('a')
+                                .setBooleanField(true)
+                                .setIntField(4)
+                                .setObjectListField(List.of(1))),
+                is(false));
+    }
+}

--- a/data.base.api/src/test/java/ru/tinkoff/qa/neptune/data/base/test/persistable/object/ToStringTest.java
+++ b/data.base.api/src/test/java/ru/tinkoff/qa/neptune/data/base/test/persistable/object/ToStringTest.java
@@ -19,6 +19,6 @@ public class ToStringTest {
                 .setObjectListField(List.of(1.5, 2.1, 3.2));
         String stringValue = p1.toString();
         PersistableObjectThree p2 = new Gson().fromJson(stringValue, PersistableObjectThree.class);
-        assertThat(p1.toString(), equalTo(p2.toString()));
+        assertThat(p1, equalTo(p2));
     }
 }

--- a/data.base.api/src/test/java/ru/tinkoff/qa/neptune/data/base/test/persistable/object/operations/select/SelectByTypedQuery.java
+++ b/data.base.api/src/test/java/ru/tinkoff/qa/neptune/data/base/test/persistable/object/operations/select/SelectByTypedQuery.java
@@ -669,18 +669,4 @@ public class SelectByTypedQuery extends BaseDbOperationTest {
             dataBaseSteps.switchToDefault();
         }
     }
-
-    @Test
-    public void equalityTest() {
-        Author pushkin = dataBaseSteps.get(aSingleByQuery(ofType(Author.class)
-                .where(QAuthor.candidate().lastName.eq("Pushkin"))));
-
-        QBook qBook = QBook.candidate();
-        Book ruslanAndLudmila = dataBaseSteps.get(aSingleByQuery(ofType(Book.class)
-                .where(qBook.author.eq(pushkin))));
-        Book ruslanAndLudmila2 = dataBaseSteps.get(aSingleByQuery(ofType(Book.class)
-                .where(qBook.name.eq("Ruslan and Ludmila"))));
-
-        assertThat(ruslanAndLudmila, is(ruslanAndLudmila2));
-    }
 }

--- a/data.base.api/src/test/java/ru/tinkoff/qa/neptune/data/base/test/persistable/object/operations/select/SelectByTypedQuery.java
+++ b/data.base.api/src/test/java/ru/tinkoff/qa/neptune/data/base/test/persistable/object/operations/select/SelectByTypedQuery.java
@@ -669,4 +669,18 @@ public class SelectByTypedQuery extends BaseDbOperationTest {
             dataBaseSteps.switchToDefault();
         }
     }
+
+    @Test
+    public void equalityTest() {
+        Author pushkin = dataBaseSteps.get(aSingleByQuery(ofType(Author.class)
+                .where(QAuthor.candidate().lastName.eq("Pushkin"))));
+
+        QBook qBook = QBook.candidate();
+        Book ruslanAndLudmila = dataBaseSteps.get(aSingleByQuery(ofType(Book.class)
+                .where(qBook.author.eq(pushkin))));
+        Book ruslanAndLudmila2 = dataBaseSteps.get(aSingleByQuery(ofType(Book.class)
+                .where(qBook.name.eq("Ruslan and Ludmila"))));
+
+        assertThat(ruslanAndLudmila, is(ruslanAndLudmila2));
+    }
 }


### PR DESCRIPTION
- Reverted previous commit https://github.com/TinkoffCreditSystems/neptune/commit/a30c97d5976a7b498b32b12b9522f3f392bbda15.
- fixed equals method of PersistableObject