### PR TITLE
Added URLValuePropertySupplier

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    globalVersion = '0.6.1-ALPHA'
+    globalVersion = '0.6.2-ALPHA'
 }
 
 subprojects {
@@ -44,6 +44,7 @@ subprojects {
             exclude group: 'com.google.guava'
             exclude group: 'com.google.code.gson'
         }
+        compile group: 'commons-validator', name: 'commons-validator', version: '1.6'
     }
 
     test {

--- a/core.api/src/main/java/ru/tinkoff/qa/neptune/core/api/conditions/ToGetConditionalHelper.java
+++ b/core.api/src/main/java/ru/tinkoff/qa/neptune/core/api/conditions/ToGetConditionalHelper.java
@@ -49,12 +49,15 @@ final class ToGetConditionalHelper {
 
     static Duration checkSleepingTime(Duration duration) {
         checkArgument(duration != null, "Time of the sleeping is not defined");
+        checkArgument(!duration.isNegative(), "Time of the sleeping should be positive");
         return duration;
     }
 
     static Duration checkWaitingTime(Duration duration) {
         checkArgument(duration != null, "Time of the waiting for some " +
                 "valuable result is not defined");
+        checkArgument(!duration.isNegative(), "Time of the waiting for some " +
+                "valuable should be positive");
         return duration;
     }
 

--- a/core.api/src/main/java/ru/tinkoff/qa/neptune/core/api/properties/url/URLValuePropertySupplier.java
+++ b/core.api/src/main/java/ru/tinkoff/qa/neptune/core/api/properties/url/URLValuePropertySupplier.java
@@ -1,0 +1,25 @@
+package ru.tinkoff.qa.neptune.core.api.properties.url;
+
+import ru.tinkoff.qa.neptune.core.api.properties.PropertySupplier;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * This interface is designed to read properties and return an URL.
+ */
+public interface URLValuePropertySupplier extends PropertySupplier<URL> {
+
+    @Override
+    default URL get() {
+        return returnOptionalFromEnvironment()
+                .map(s -> {
+                    try {
+                        return new URL(s);
+                    } catch (MalformedURLException e) {
+                        throw new IllegalArgumentException(e.getMessage(), e);
+                    }
+                })
+                .orElse(null);
+    }
+}

--- a/http.api/src/main/java/ru/tinkoff/qa/neptune/http/api/properties/DefaultHttpDomainToRespondProperty.java
+++ b/http.api/src/main/java/ru/tinkoff/qa/neptune/http/api/properties/DefaultHttpDomainToRespondProperty.java
@@ -1,0 +1,37 @@
+package ru.tinkoff.qa.neptune.http.api.properties;
+
+import ru.tinkoff.qa.neptune.core.api.properties.url.URLValuePropertySupplier;
+import ru.tinkoff.qa.neptune.http.api.HttpRequestGetSupplier;
+
+import java.net.http.HttpRequest;
+
+/**
+ * This class is designed to read value of the property {@code 'default.http.domain.to.respond'} and convert it to
+ * {@link java.net.URL}. This is the frequently uses domain of the service to respond. It makes possible to use
+ * relative (part of the) URI by {@link HttpRequestGetSupplier#GET(java.lang.String)},
+ * {@link HttpRequestGetSupplier#POST(String, HttpRequest.BodyPublisher)},
+ * {@link HttpRequestGetSupplier#PUT(String, HttpRequest.BodyPublisher)},
+ * {@link HttpRequestGetSupplier#DELETE(String)},
+ * {@link HttpRequestGetSupplier#methodRequest(String, String)} and
+ * {@link HttpRequestGetSupplier#methodRequest(String, String, HttpRequest.BodyPublisher)}
+ */
+public final class DefaultHttpDomainToRespondProperty implements URLValuePropertySupplier {
+
+    private static final String PROPERTY = "default.http.domain.to.respond";
+
+    /**
+     * This instance reads value of the property {@code 'default.http.domain.to.respond'} and returns an {@link java.net.URL}.
+     * This is the frequently uses domain of the service to respond.
+     */
+    public static final DefaultHttpDomainToRespondProperty DEFAULT_HTTP_DOMAIN_TO_RESPOND_PROPERTY =
+            new DefaultHttpDomainToRespondProperty();
+
+    private DefaultHttpDomainToRespondProperty() {
+        super();
+    }
+
+    @Override
+    public String getPropertyName() {
+        return PROPERTY;
+    }
+}

--- a/http.api/src/test/java/ru/tinkoff/qa/neptune/http/api/test/HttpClientTest.java
+++ b/http.api/src/test/java/ru/tinkoff/qa/neptune/http/api/test/HttpClientTest.java
@@ -38,6 +38,7 @@ import static ru.tinkoff.qa.neptune.http.api.HttpRequestGetSupplier.GET;
 import static ru.tinkoff.qa.neptune.http.api.HttpResponseSequentialGetSupplier.responseOf;
 import static ru.tinkoff.qa.neptune.http.api.properties.DefaultHttpAuthenticatorProperty.DEFAULT_HTTP_AUTHENTICATOR_PROPERTY;
 import static ru.tinkoff.qa.neptune.http.api.properties.DefaultHttpCookieManagerProperty.DEFAULT_HTTP_COOKIE_MANAGER_PROPERTY;
+import static ru.tinkoff.qa.neptune.http.api.properties.DefaultHttpDomainToRespondProperty.DEFAULT_HTTP_DOMAIN_TO_RESPOND_PROPERTY;
 import static ru.tinkoff.qa.neptune.http.api.properties.DefaultHttpExecutorProperty.DEFAULT_HTTP_EXECUTOR_PROPERTY;
 import static ru.tinkoff.qa.neptune.http.api.properties.DefaultHttpPriorityProperty.DEFAULT_HTTP_PRIORITY_PROPERTY;
 import static ru.tinkoff.qa.neptune.http.api.properties.DefaultHttpProtocolVersionProperty.DEFAULT_HTTP_PROTOCOL_VERSION_PROPERTY;
@@ -207,6 +208,20 @@ public class HttpClientTest extends BaseHttpTest {
         client = httpSteps.getCurrentClient();
 
         assertThat(client, equalTo(defaultClient));
+    }
+
+    @Test
+    public void abilityToUseRelativeURIPathTest() {
+        setProperty(DEFAULT_HTTP_DOMAIN_TO_RESPOND_PROPERTY.getPropertyName(), REQUEST_URI);
+        var httpSteps = getProxied(HttpSteps.class);
+
+        try {
+            assertThat(httpSteps.get(responseOf(GET("/index.html"), ofString())).body(),
+                    equalTo("Hello"));
+        }
+        finally {
+            getProperties().remove(DEFAULT_HTTP_DOMAIN_TO_RESPOND_PROPERTY.getPropertyName());
+        }
     }
 
     @Test

--- a/selenium/build.gradle
+++ b/selenium/build.gradle
@@ -11,7 +11,6 @@ dependencies {
         exclude group: 'com.google.code.gson'
     }
     compile group: 'cglib', name: 'cglib', version: '3.2.9'
-    compile group: 'commons-validator', name: 'commons-validator', version: '1.6'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '2.23.0'
 }
 

--- a/selenium/src/main/java/ru/tinkoff/qa/neptune/selenium/functions/navigation/ToUrl.java
+++ b/selenium/src/main/java/ru/tinkoff/qa/neptune/selenium/functions/navigation/ToUrl.java
@@ -12,7 +12,7 @@ import static ru.tinkoff.qa.neptune.selenium.functions.target.locator.window.Get
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static ru.tinkoff.qa.neptune.selenium.properties.SessionFlagProperties.ENABLE_ABILITY_TO_USE_RELATIVE_URL;
+import static ru.tinkoff.qa.neptune.selenium.properties.SessionFlagProperties.ENABLE_ABILITY_TO_NAVIGATE_BY_RELATIVE_URL;
 import static ru.tinkoff.qa.neptune.selenium.properties.URLProperties.BASE_WEB_DRIVER_URL_PROPERTY;
 
 public final class ToUrl extends NavigationActionSupplier<ToUrl> {
@@ -30,7 +30,7 @@ public final class ToUrl extends NavigationActionSupplier<ToUrl> {
             toURL = url;
         }
         else {
-            if (ENABLE_ABILITY_TO_USE_RELATIVE_URL.get()) {
+            if (ENABLE_ABILITY_TO_NAVIGATE_BY_RELATIVE_URL.get()) {
                 toURL = ofNullable(BASE_WEB_DRIVER_URL_PROPERTY.get())
                         .map(url1 -> url1 + url)
                         .orElseThrow(() -> new IllegalArgumentException(format("It is impossible to navigate by URL %s. " +
@@ -40,7 +40,7 @@ public final class ToUrl extends NavigationActionSupplier<ToUrl> {
             else {
                 throw new IllegalArgumentException(format("It is impossible to navigate by URL %s. " +
                                 "This value is not a valid URL and the property %s is not defined or its value is %s", url,
-                        ENABLE_ABILITY_TO_USE_RELATIVE_URL.getPropertyName(), false));
+                        ENABLE_ABILITY_TO_NAVIGATE_BY_RELATIVE_URL.getPropertyName(), false));
             }
         }
 

--- a/selenium/src/main/java/ru/tinkoff/qa/neptune/selenium/properties/SessionFlagProperties.java
+++ b/selenium/src/main/java/ru/tinkoff/qa/neptune/selenium/properties/SessionFlagProperties.java
@@ -52,7 +52,7 @@ public enum SessionFlagProperties implements BooleanPropertySupplier {
      * <p>{@code seleniumSteps.navigate(toUrl("/relative/url/path.html")}</p>
      * <p>WARNING: it is necessary to define {@link URLProperties#BASE_WEB_DRIVER_URL_PROPERTY}</p>
      */
-    ENABLE_ABILITY_TO_USE_RELATIVE_URL("enable.ability.to.use.relative.url");
+    ENABLE_ABILITY_TO_NAVIGATE_BY_RELATIVE_URL("enable.ability.to.navigate.by.relative.url");
 
     private final String propertyName;
 

--- a/selenium/src/main/java/ru/tinkoff/qa/neptune/selenium/properties/URLProperties.java
+++ b/selenium/src/main/java/ru/tinkoff/qa/neptune/selenium/properties/URLProperties.java
@@ -1,13 +1,8 @@
 package ru.tinkoff.qa.neptune.selenium.properties;
 
-import ru.tinkoff.qa.neptune.core.api.properties.PropertySupplier;
+import ru.tinkoff.qa.neptune.core.api.properties.url.URLValuePropertySupplier;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-
-import static java.lang.String.format;
-
-public enum  URLProperties implements PropertySupplier<URL> {
+public enum URLProperties implements URLValuePropertySupplier {
     /**
      * This item read the property {@code 'remote.web.driver.url'} and returns URL to start
      * a new remote session of {@link org.openqa.selenium.WebDriver}
@@ -31,17 +26,5 @@ public enum  URLProperties implements PropertySupplier<URL> {
     @Override
     public String getPropertyName() {
         return propertyName;
-    }
-
-    @Override
-    public URL get() {
-        return returnOptionalFromEnvironment()
-                .map(s -> {
-                    try {
-                        return new URL(s);
-                    } catch (MalformedURLException e) {
-                        throw new RuntimeException(format("URL %s is malformed", s), e);
-                    }
-                }).orElse(null);
     }
 }

--- a/selenium/src/test/java/ru/tinkoff/qa/neptune/selenium/test/steps/tests/navigation/NavigationTest.java
+++ b/selenium/src/test/java/ru/tinkoff/qa/neptune/selenium/test/steps/tests/navigation/NavigationTest.java
@@ -19,7 +19,7 @@ import static ru.tinkoff.qa.neptune.selenium.functions.navigation.GetCurrentUrlS
 import static ru.tinkoff.qa.neptune.selenium.functions.navigation.Refresh.refresh;
 import static ru.tinkoff.qa.neptune.selenium.functions.navigation.ToUrl.toUrl;
 import static ru.tinkoff.qa.neptune.selenium.functions.target.locator.window.GetWindowSupplier.window;
-import static ru.tinkoff.qa.neptune.selenium.properties.SessionFlagProperties.ENABLE_ABILITY_TO_USE_RELATIVE_URL;
+import static ru.tinkoff.qa.neptune.selenium.properties.SessionFlagProperties.ENABLE_ABILITY_TO_NAVIGATE_BY_RELATIVE_URL;
 import static ru.tinkoff.qa.neptune.selenium.properties.SessionFlagProperties.GET_BACK_TO_BASE_URL;
 import static ru.tinkoff.qa.neptune.selenium.properties.URLProperties.BASE_WEB_DRIVER_URL_PROPERTY;
 import static ru.tinkoff.qa.neptune.selenium.properties.WaitingProperties.TimeUnitProperties.WAITING_FOR_PAGE_LOADED_TIME_UNIT;
@@ -69,7 +69,7 @@ public class NavigationTest extends BaseWebDriverTest {
             expectedExceptionsMessageRegExp = "It is impossible to navigate by URL /index.html. " +
                     "This value is not a valid URL and the property base.web.driver.url is not defined")
     public void invalidNavigationByRelativeUrl2() {
-        System.setProperty(ENABLE_ABILITY_TO_USE_RELATIVE_URL.getPropertyName(), "true");
+        System.setProperty(ENABLE_ABILITY_TO_NAVIGATE_BY_RELATIVE_URL.getPropertyName(), "true");
         try {
             seleniumSteps.navigate(toUrl("/index.html"));
             assertThat(seleniumSteps.get(currentUrl()), containsString("/index.html"));
@@ -82,7 +82,7 @@ public class NavigationTest extends BaseWebDriverTest {
     @Test
     public void validNavigationByRelativeUrl() {
         System.setProperty(BASE_WEB_DRIVER_URL_PROPERTY.getPropertyName(), GITHUB.getUrl());
-        System.setProperty(ENABLE_ABILITY_TO_USE_RELATIVE_URL.getPropertyName(), "true");
+        System.setProperty(ENABLE_ABILITY_TO_NAVIGATE_BY_RELATIVE_URL.getPropertyName(), "true");
         try {
             seleniumSteps.navigate(toUrl("/index.html"));
             assertThat(seleniumSteps.get(currentUrl()), containsString(GITHUB.getUrl()));


### PR DESCRIPTION
- new interface URLValuePropertySupplier to read properties and to convert their values to URL
- URLProperties implements URLValuePropertySupplier [Selenium]
- SessionFlagProperties#ENABLE_ABILITY_TO_USE_RELATIVE_URL was renamed to SessionFlagProperties#ENABLE_ABILITY_TO_NAVIGATE_BY_RELATIVE_URL. The name of the property to read was changed as well. [Selenium]
- DefaultHttpDomainToRespondProperty was added [Http #36]
- HttpRequestGetSupplier was modified [Http #36]