### PR TITLE
HttpResponse captors [HTTP]. Get/add/delete browser cookies [SELENIUM]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    globalVersion = '0.6.5-ALPHA'
+    globalVersion = '0.6.6-ALPHA'
 }
 
 subprojects {

--- a/http.api/build.gradle
+++ b/http.api/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     compile project(':core.api')
+    compile group: 'commons-io', name: 'commons-io', version: '2.6'
     compile group: 'org.glassfish.jersey.core', name: 'jersey-common', version: '2.27'
     testCompile group: 'org.mock-server', name: 'mockserver-netty', version: '5.4.1'
     testCompile group: 'org.mock-server', name: 'mockserver-client-java', version: '5.4.1'

--- a/http.api/src/main/java/ru/tinkoff/qa/neptune/http/api/captors/ResponseFileCaptor.java
+++ b/http.api/src/main/java/ru/tinkoff/qa/neptune/http/api/captors/ResponseFileCaptor.java
@@ -1,0 +1,85 @@
+package ru.tinkoff.qa.neptune.http.api.captors;
+
+import ru.tinkoff.qa.neptune.core.api.event.firing.captors.FileCaptor;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.http.HttpResponse;
+import java.nio.file.Path;
+
+
+import static com.google.common.io.Files.getFileExtension;
+import static com.google.common.io.Files.getNameWithoutExtension;
+import static java.io.File.createTempFile;
+import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
+import static java.util.UUID.randomUUID;
+import static org.apache.commons.io.FileUtils.copyFile;
+import static org.apache.commons.io.FileUtils.writeStringToFile;
+
+/**
+ * This class is designed to convert some {@link String} and {@link Path} bodies of received responses
+ * to files.
+ */
+public class ResponseFileCaptor extends FileCaptor<HttpResponse> {
+
+    public ResponseFileCaptor() {
+        super();
+    }
+
+    public void capture(HttpResponse caught, String message) {
+        super.capture(caught, format("Received response. %s", message));
+    }
+
+    @Override
+    protected File getData(HttpResponse caught) {
+        var body = caught.body();
+        var uuid = randomUUID().toString();
+
+        return ofNullable(body)
+                .map(o -> {
+                    Class<?> clazz = o.getClass();
+                    if (Path.class.isAssignableFrom(clazz)) {
+                        var path = (Path) o;
+                        File file = path.toFile();
+
+                        if (file.exists()) {
+                            var absolutePath = file.getAbsolutePath();
+                            try {
+                                var tempFile = createTempFile(format("%s_%s", getNameWithoutExtension(absolutePath), uuid),
+                                        getFileExtension(absolutePath));
+                                tempFile.deleteOnExit();
+                                copyFile(file, tempFile);
+                                return tempFile;
+                            } catch (IOException e) {
+                                return null;
+                            }
+                        }
+                        else {
+                            return null;
+                        }
+                    }
+
+                    if (String.class.equals(o.getClass())) {
+                        var stringBody = (String.valueOf(o));
+                        try {
+                            var tempFile = createTempFile(format("StringBodyOfResponse_%s", uuid),
+                                    ".txt");
+                            tempFile.deleteOnExit();
+                            writeStringToFile(tempFile, stringBody, "UTF-8", true);
+                            return tempFile;
+                        } catch (IOException e) {
+                            return null;
+                        }
+                    }
+
+                    return null;
+                })
+                .orElse(null);
+    }
+
+    @Override
+    public Class<HttpResponse> getTypeToBeCaptured() {
+        return HttpResponse.class;
+    }
+}

--- a/http.api/src/main/resources/META-INF/services/ru.tinkoff.qa.neptune.core.api.event.firing.Captor
+++ b/http.api/src/main/resources/META-INF/services/ru.tinkoff.qa.neptune.core.api.event.firing.Captor
@@ -1,0 +1,1 @@
+ru.tinkoff.qa.neptune.http.api.captors.ResponseFileCaptor

--- a/selenium/src/main/java/ru/tinkoff/qa/neptune/selenium/functions/cookies/AddCookiesActionSupplier.java
+++ b/selenium/src/main/java/ru/tinkoff/qa/neptune/selenium/functions/cookies/AddCookiesActionSupplier.java
@@ -1,0 +1,39 @@
+package ru.tinkoff.qa.neptune.selenium.functions.cookies;
+
+import org.openqa.selenium.Cookie;
+import org.openqa.selenium.WebDriver;
+import ru.tinkoff.qa.neptune.core.api.SequentialActionSupplier;
+import ru.tinkoff.qa.neptune.selenium.SeleniumSteps;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Arrays.stream;
+import static ru.tinkoff.qa.neptune.selenium.CurrentContentFunction.currentContent;
+
+/**
+ * This class is designed to build an action that adds cookies to browser's "cookie jar".
+ */
+public final class AddCookiesActionSupplier extends SequentialActionSupplier<SeleniumSteps, WebDriver, AddCookiesActionSupplier> {
+
+    private AddCookiesActionSupplier() {
+        super();
+    }
+
+    /**
+     * Creates an instance of {@link AddCookiesActionSupplier}
+     *
+     * @param cookies to be added
+     * @return an instance of {@link AddCookiesActionSupplier}
+     */
+    public static AddCookiesActionSupplier addCookies(Cookie...cookies) {
+        checkArgument(cookies != null, "Cookies to be add should not be a null value");
+        checkArgument(cookies.length > 0, "At least one cookie should be defined for the adding");
+        return new AddCookiesActionSupplier().andThen("Adding the cookies",
+                currentContent(), (Object[]) cookies);
+    }
+
+    @Override
+    protected void performActionOn(WebDriver value, Object... additionalArgument) {
+        stream(additionalArgument).map(o -> (Cookie) o)
+                .forEach(cookie -> value.manage().addCookie(cookie));
+    }
+}

--- a/selenium/src/main/java/ru/tinkoff/qa/neptune/selenium/functions/cookies/GetSeleniumCookieSupplier.java
+++ b/selenium/src/main/java/ru/tinkoff/qa/neptune/selenium/functions/cookies/GetSeleniumCookieSupplier.java
@@ -1,0 +1,64 @@
+package ru.tinkoff.qa.neptune.selenium.functions.cookies;
+
+import org.openqa.selenium.Cookie;
+import org.openqa.selenium.WebDriver;
+import ru.tinkoff.qa.neptune.core.api.SequentialGetStepSupplier;
+import ru.tinkoff.qa.neptune.selenium.SeleniumSteps;
+
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static java.util.Optional.ofNullable;
+import static ru.tinkoff.qa.neptune.core.api.StoryWriter.toGet;
+import static ru.tinkoff.qa.neptune.core.api.conditions.ToGetSubIterable.getIterable;
+import static ru.tinkoff.qa.neptune.selenium.CurrentContentFunction.currentContent;
+
+/**
+ * This class is designed to build chain of functions that get cookies of a browser.
+ */
+public final class GetSeleniumCookieSupplier extends SequentialGetStepSupplier<SeleniumSteps, Set<Cookie>, WebDriver, GetSeleniumCookieSupplier> {
+
+    private Predicate<Cookie> cookiePredicate;
+
+    private GetSeleniumCookieSupplier() {
+        super();
+    }
+
+    /**
+     * Creates an instance of {@link GetSeleniumCookieSupplier} that builds a chain of functions that get cookies
+     * of a browser.
+     *
+     * @return an instance of {@link GetSeleniumCookieSupplier}
+     */
+    public static GetSeleniumCookieSupplier cookies() {
+        return new GetSeleniumCookieSupplier();
+    }
+
+    @Override
+    public Function<SeleniumSteps, Set<Cookie>> get() {
+        return ofNullable(super.get()).orElseGet(() -> {
+            super.from(currentContent());
+            return super.get();
+        });
+    }
+
+    /**
+     * Sets a predicate that represents criteria to get cookies. These cookies should meet the criteria.
+     *
+     * @param condition a predicate that represents criteria to get cookies.
+     * @return self-reference
+     */
+    public GetSeleniumCookieSupplier withCondition(Predicate<Cookie> condition) {
+        this.cookiePredicate = condition;
+        return this;
+    }
+
+    @Override
+    protected Function<WebDriver, Set<Cookie>> getEndFunction() {
+        var func = (Function<WebDriver, Set<Cookie>>) driver -> driver.manage().getCookies();
+        return ofNullable(cookiePredicate)
+                .map(condition -> getIterable("Cookies", func, condition, true, true))
+                .orElseGet(() -> toGet("Cookies", func));
+    }
+}

--- a/selenium/src/main/java/ru/tinkoff/qa/neptune/selenium/functions/cookies/RemoveCookiesActionSupplier.java
+++ b/selenium/src/main/java/ru/tinkoff/qa/neptune/selenium/functions/cookies/RemoveCookiesActionSupplier.java
@@ -1,0 +1,69 @@
+package ru.tinkoff.qa.neptune.selenium.functions.cookies;
+
+import org.openqa.selenium.Cookie;
+import org.openqa.selenium.WebDriver;
+import ru.tinkoff.qa.neptune.core.api.SequentialActionSupplier;
+import ru.tinkoff.qa.neptune.selenium.SeleniumSteps;
+
+import static java.util.Arrays.stream;
+import static ru.tinkoff.qa.neptune.selenium.CurrentContentFunction.currentContent;
+
+/**
+ * This class is designed to build an action that removes cookies from browser's "cookie jar".
+ */
+public abstract class RemoveCookiesActionSupplier<T> extends SequentialActionSupplier<SeleniumSteps, T, RemoveCookiesActionSupplier<T>> {
+
+    private RemoveCookiesActionSupplier() {
+        super();
+    }
+
+    /**
+     * Creates an instance of {@link RemoveCookiesActionSupplier}
+     *
+     * @param getCookies is the way how to get browser cookies to be removed from the jar
+     * @return an instance of {@link RemoveCookiesActionSupplier}
+     */
+    public static RemoveCookiesActionSupplier<SeleniumSteps> deleteCookies(GetSeleniumCookieSupplier getCookies) {
+        return new RemoveCookiesActionSupplier<SeleniumSteps>() {
+            @Override
+            protected void performActionOn(SeleniumSteps value, Object... additionalArgument) {
+                stream(additionalArgument)
+                        .map(o -> (GetSeleniumCookieSupplier) o)
+                        .forEach(getSeleniumCookieSupplier -> {
+                            var toBeDeleted = value.get(getSeleniumCookieSupplier);
+                            toBeDeleted.forEach(cookie -> value.getWrappedDriver().manage().deleteCookie(cookie));
+                        });
+            }
+        }.andThen("The deleting from browser's cookie jar", seleniumSteps -> seleniumSteps, getCookies);
+    }
+
+    /**
+     * Creates an instance of {@link RemoveCookiesActionSupplier}
+     *
+     * @param cookies browser cookies to be removed from the jar
+     * @return an instance of {@link RemoveCookiesActionSupplier}
+     */
+    public static RemoveCookiesActionSupplier<WebDriver> deleteCookies(Cookie...cookies) {
+        return new RemoveCookiesActionSupplier<WebDriver>() {
+            @Override
+            protected void performActionOn(WebDriver value, Object... additionalArgument) {
+                stream(additionalArgument).map(o -> (Cookie) o)
+                        .forEach(cookie -> value.manage().deleteCookie(cookie));
+            }
+        }.andThen("The deleting from browser's cookie jar", currentContent(), (Object[]) cookies);
+    }
+
+    /**
+     * Creates an instance of {@link RemoveCookiesActionSupplier}
+     *
+     * @return an instance of {@link RemoveCookiesActionSupplier}
+     */
+    public static RemoveCookiesActionSupplier<WebDriver> deleteAllCookies() {
+        return new RemoveCookiesActionSupplier<WebDriver>() {
+            @Override
+            protected void performActionOn(WebDriver value, Object... additionalArgument) {
+                value.manage().deleteAllCookies();
+            }
+        }.andThen("The deleting all the cookies from browser's cookie jar", currentContent());
+    }
+}

--- a/selenium/src/test/java/ru/tinkoff/qa/neptune/selenium/test/MockOptions.java
+++ b/selenium/src/test/java/ru/tinkoff/qa/neptune/selenium/test/MockOptions.java
@@ -4,6 +4,8 @@ import org.openqa.selenium.Cookie;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.logging.Logs;
 
+import java.util.Date;
+import java.util.HashSet;
 import java.util.Set;
 
 import static ru.tinkoff.qa.neptune.selenium.test.enums.InitialPositions.POSITION_1;
@@ -23,6 +25,16 @@ public class MockOptions implements WebDriver.Options {
 
     private final MockWebDriver driver;
 
+    private final Set<Cookie> cookieJar = new HashSet<>(){
+        {
+            add(new Cookie("key1", "value1", "youtube.com", "some/path", new Date(), true));
+            add(new Cookie("key2", "value2", "www.google.com", "some/path2", new Date(), false));
+            add(new Cookie("key3", "value3", "github.com", "some/path3", new Date(), false));
+            add(new Cookie("key4", "value4", "paypal.com", "some/path4", new Date(), true));
+            add(new Cookie("key5", "value5", "deezer.com", "some/path5", new Date(), false));
+        }
+    };
+
     MockOptions(MockWebDriver driver) {
         this.driver = driver;
         window1 = new MockWindow(SIZE1.getSize(), POSITION_1.getPosition());
@@ -32,7 +44,7 @@ public class MockOptions implements WebDriver.Options {
 
     @Override
     public void addCookie(Cookie cookie) {
-        //Todo Does nothing for now
+        cookieJar.add(cookie);
     }
 
     @Override
@@ -42,17 +54,17 @@ public class MockOptions implements WebDriver.Options {
 
     @Override
     public void deleteCookie(Cookie cookie) {
-        //Todo Does nothing for now
+        cookieJar.remove(cookie);
     }
 
     @Override
     public void deleteAllCookies() {
-        //Todo Does nothing for now
+        cookieJar.clear();
     }
 
     @Override
     public Set<Cookie> getCookies() {
-        return null;
+        return new HashSet<>(cookieJar);
     }
 
     @Override

--- a/selenium/src/test/java/ru/tinkoff/qa/neptune/selenium/test/steps/tests/cookies/CookieTest.java
+++ b/selenium/src/test/java/ru/tinkoff/qa/neptune/selenium/test/steps/tests/cookies/CookieTest.java
@@ -1,0 +1,80 @@
+package ru.tinkoff.qa.neptune.selenium.test.steps.tests.cookies;
+
+import org.openqa.selenium.Cookie;
+import org.testng.annotations.Test;
+import ru.tinkoff.qa.neptune.selenium.test.BaseWebDriverTest;
+
+import java.util.Date;
+import java.util.HashSet;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyCollectionOf;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static ru.tinkoff.qa.neptune.core.api.StoryWriter.condition;
+import static ru.tinkoff.qa.neptune.selenium.functions.cookies.AddCookiesActionSupplier.addCookies;
+import static ru.tinkoff.qa.neptune.selenium.functions.cookies.GetSeleniumCookieSupplier.cookies;
+import static ru.tinkoff.qa.neptune.selenium.functions.cookies.RemoveCookiesActionSupplier.deleteAllCookies;
+import static ru.tinkoff.qa.neptune.selenium.functions.cookies.RemoveCookiesActionSupplier.deleteCookies;
+
+public class CookieTest extends BaseWebDriverTest {
+
+    @Test
+    public void getAllCookieTest() {
+        var cookies = seleniumSteps.get(cookies());
+        assertThat(new HashSet<>(cookies), equalTo(seleniumSteps.getWrappedDriver().manage().getCookies()));
+    }
+
+    @Test(priority = 1)
+    public void getCookieConditionalTest() {
+        var cookies = seleniumSteps.get(cookies()
+                .withCondition(condition("Cookie has domain 'paypal.com' and isSecure = true",
+                        cookie -> cookie.getDomain().equals("paypal.com")
+                                && cookie.isSecure())));
+        assertThat(cookies, hasSize(1));
+    }
+
+    @Test(priority = 2)
+    public void addCookieTest() {
+        var cookie1 = new Cookie("key6", "value6", "wikipedia.org", "some/path6", new Date(), true);
+        var cookie2 = new Cookie("key7", "value7", "oracle.com", "some/path7", new Date(), false);
+
+        var cookies = seleniumSteps.perform(addCookies(cookie1, cookie2))
+                .get(cookies());
+        assertThat(cookies, hasItems(cookie1, cookie2));
+    }
+
+    @Test(priority = 3)
+    public void removeCookiesWithSearchingTest() {
+        var cookies = seleniumSteps.get(cookies()
+                .withCondition(condition("Cookie has domain 'paypal.com' and isSecure = true",
+                        cookie -> cookie.getDomain().equals("paypal.com"))));
+
+        var cookies2 = seleniumSteps.perform(deleteCookies(cookies()
+                .withCondition(condition("Cookie has domain 'paypal.com' and isSecure = true",
+                        cookie -> cookie.getDomain().equals("paypal.com")))))
+                .get(cookies());
+
+        assertThat(cookies2, not(hasItems(cookies.toArray(new Cookie[]{}))));
+    }
+
+    @Test(priority = 5)
+    public void removeCookiesTest() {
+        var cookie1 = new Cookie("key2", "value2", "www.google.com", "some/path2", new Date(), false);
+        var cookie2 = new Cookie("key3", "value3", "github.com", "some/path3", new Date(), false);
+
+        var cookies = seleniumSteps.perform(deleteCookies(cookie1, cookie2))
+                .get(cookies());
+
+        assertThat(cookies, not(hasItems(cookie1, cookie2)));
+    }
+
+    @Test(priority = 4)
+    public void removeAllCookiesTest() {
+        var cookies = seleniumSteps.perform(deleteAllCookies())
+                .get(cookies());
+        assertThat(cookies, emptyCollectionOf(Cookie.class));
+    }
+}


### PR DESCRIPTION
- added ResponseFileCaptor to report about received http responses #36
- added GetSeleniumCookieSupplier to get cookies from browser's cookie jar
- added AddCookiesActionSupplier to add cookies to browser's cookie jar
- added RemoveCookiesActionSupplier to remove cookies from browser's cookie jar