### PR TITLE
Http serializers:

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    globalVersion = '0.9.23-ALPHA'
+    globalVersion = '0.10.1-ALPHA'
 }
 
 subprojects {
@@ -26,8 +26,8 @@ subprojects {
         testNGVersion = '6.14.3'
         hamcrestVersion = '2.1'
         seleniumVersion = '3.141.59'
-        allureVersion = '2.12.1'
-        jacksonVersion = '2.10.0.pr1'
+        allureVersion = '2.13.0'
+        jacksonVersion = '2.10.0.pr2'
         mavenDeployLogin = hasProperty('REPO_USER_NAME') ? REPO_USER_NAME : System.getenv('REPO_USER_NAME')
         mavenDeployPassword = hasProperty('REPO_USER_PASSWORD') ? REPO_USER_NAME : System.getenv('REPO_USER_PASSWORD')
         globalVersion = version
@@ -35,12 +35,13 @@ subprojects {
 
     dependencies {
         compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'
-        compile group: 'com.google.guava', name: 'guava', version: '28.0-jre'
+        compile group: 'com.google.guava', name: 'guava', version: '28.1-jre'
         testCompile group: 'org.testng', name: 'testng', version: testNGVersion
         testCompile group: 'org.hamcrest', name: 'hamcrest', version: hamcrestVersion
         compile group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'
         compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion
         compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-jaxb-annotations', version: jacksonVersion
+        compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-xml', version: jacksonVersion
         compile (group: 'org.reflections', name: 'reflections', version: '0.9.11') {
             exclude group: 'com.google.guava'
             exclude group: 'com.google.code.gson'

--- a/http.api/build.gradle
+++ b/http.api/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     compile project(':core.api')
     compile group: 'org.glassfish.jersey.core', name: 'jersey-common', version: '2.28'
+    compile group: 'org.jsoup', name: 'jsoup', version: '1.12.1'
     testCompile group: 'org.mock-server', name: 'mockserver-netty', version: '5.5.1'
     testCompile group: 'org.mock-server', name: 'mockserver-client-java', version: '5.5.1'
 }

--- a/http.api/src/main/java/ru/tinkoff/qa/neptune/http/api/CommonBodyPublishers.java
+++ b/http.api/src/main/java/ru/tinkoff/qa/neptune/http/api/CommonBodyPublishers.java
@@ -291,9 +291,7 @@ public final class CommonBodyPublishers {
     }
 
     /**
-     * Transforms a map to to string body of a request. It is expected that keys of a map are parameter names
-     * and values are values of defined parameters. Resulted string body looks like following string
-     * {@code key1=val1&key2=val2}
+     * Transforms a map to to string body of {@code application/x-www-form-urlencoded} format
      *
      * @param formParameters is a map where keys are parameter names and values are values of defined parameters
      * @return a BodyPublisher

--- a/http.api/src/main/java/ru/tinkoff/qa/neptune/http/api/CommonBodyPublishers.java
+++ b/http.api/src/main/java/ru/tinkoff/qa/neptune/http/api/CommonBodyPublishers.java
@@ -1,7 +1,17 @@
 package ru.tinkoff.qa.neptune.http.api;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.GsonBuilder;
+import org.w3c.dom.Document;
+
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
+import java.io.StringWriter;
 import java.net.http.HttpRequest;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -9,8 +19,10 @@ import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.function.Supplier;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.net.http.HttpRequest.BodyPublishers.*;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.nonNull;
 
 /**
  * Creates instances if {@link java.net.http.HttpRequest.BodyPublisher} for more comfort usage
@@ -124,5 +136,128 @@ public final class CommonBodyPublishers {
      */
     public static HttpRequest.BodyPublisher empty() {
         return noBody();
+    }
+
+    /**
+     * Serializes given object to json string for the using it as a request body
+     *
+     * @param t is an object to be serialized to json string
+     * @param builder is used for the serialization
+     * @param charset of a resulted request body
+     * @param <T> is a type of the object to be serialized
+     * @return a BodyPublisher
+     */
+    public static  <T> HttpRequest.BodyPublisher jsonStringBody(T t, GsonBuilder builder, Charset charset) {
+        checkArgument(nonNull(builder), "Json builder should not be a null value");
+        checkArgument(nonNull(charset), "Char set should not be a null value");
+        return ofString(builder.create().toJson(t), charset);
+    }
+
+    /**
+     * Serializes given object to json string for the using it as a request body
+     *
+     * @param t is an object to be serialized to json string
+     * @param builder is used for the serialization
+     * @param <T> is a type of the object to be serialized
+     * @return a BodyPublisher
+     */
+    public static  <T> HttpRequest.BodyPublisher jsonStringBody(T t, GsonBuilder builder) {
+        return jsonStringBody(t, builder, UTF_8);
+    }
+
+    /**
+     * Serializes given object to json/xml string for the using it as a request body. The serializing is
+     * performed by Jackson
+     *
+     * @param t is an object to be serialized to json string
+     * @param mapper is an object mapper
+     * @param charset  of a resulted request body
+     * @param <T> is a type of the object to be serialized
+     * @return a BodyPublisher
+     */
+    public static  <T> HttpRequest.BodyPublisher serializedStringBody(T t, ObjectMapper mapper, Charset charset) {
+        checkArgument(nonNull(t), "Object to be serialized should not be a null value");
+        checkArgument(nonNull(mapper), "Object mapper should not be a null value");
+        checkArgument(nonNull(charset), "Char set should not be a null value");
+        try {
+            return ofString(mapper.writeValueAsString(t), charset);
+        } catch (JsonProcessingException e) {
+           throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Serializes given object to json/xml string for the using it as a request body. The serializing is
+     * performed by Jackson
+     *
+     * @param t is an object to be serialized to json string
+     * @param mapper is an object mapper
+     * @param <T> is a type of the object to be serialized
+     * @return a BodyPublisher
+     */
+    public static <T> HttpRequest.BodyPublisher serializedStringBody(T t, ObjectMapper mapper) {
+        return serializedStringBody(t, mapper, UTF_8);
+    }
+
+    /**
+     * Transforms given xml/html document to string body of a request.
+     *
+     * @param document is xml/html document to be used
+     * @param transformer is a transformer of the document to string value
+     * @param charset of a resulted request body
+     * @return a BodyPublisher
+     */
+    public static  HttpRequest.BodyPublisher documentStringBody(Document document,
+                                                                Transformer transformer,
+                                                                Charset charset) {
+        checkArgument(nonNull(document), "Document should not be a null value");
+        checkArgument(nonNull(transformer), "Transformer should not be a null value");
+        checkArgument(nonNull(charset), "Char set should not be a null value");
+
+        DOMSource domSource = new DOMSource(document);
+
+        var sw = new StringWriter();
+        StreamResult sr = new StreamResult(sw);
+        try {
+            transformer.transform(domSource, sr);
+            return ofString(sw.toString(), charset);
+        } catch (TransformerException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Transforms given xml/html document to string body of a request.
+     *
+     * @param document is xml/html document to be used
+     * @param transformer is a transformer of the document to string value
+     * @return a BodyPublisher
+     */
+    public static HttpRequest.BodyPublisher documentStringBody(Document document, Transformer transformer) {
+        return documentStringBody(document, transformer, UTF_8);
+    }
+
+    /**
+     * Transforms given html document to string body of a request.
+     *
+     * @param document is html document to be used
+     * @param charset of a resulted request body
+     * @return a BodyPublisher
+     */
+    public static  HttpRequest.BodyPublisher documentStringBody(org.jsoup.nodes.Document document,
+                                                                Charset charset) {
+        checkArgument(nonNull(document), "Document should not be a null value");
+        checkArgument(nonNull(charset), "Char set should not be a null value");
+        return ofString(document.outerHtml(), charset);
+    }
+
+    /**
+     * Transforms given html document to string body of a request.
+     *
+     * @param document is html document to be used
+     * @return a BodyPublisher
+     */
+    public static  HttpRequest.BodyPublisher documentStringBody(org.jsoup.nodes.Document document) {
+        return documentStringBody(document, UTF_8);
     }
 }

--- a/http.api/src/main/java/ru/tinkoff/qa/neptune/http/api/CommonBodyPublishers.java
+++ b/http.api/src/main/java/ru/tinkoff/qa/neptune/http/api/CommonBodyPublishers.java
@@ -3,7 +3,6 @@ package ru.tinkoff.qa.neptune.http.api;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.GsonBuilder;
-import org.w3c.dom.Document;
 
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
@@ -144,7 +143,7 @@ public final class CommonBodyPublishers {
     }
 
     /**
-     * Serializes given object to json string for the using it as a request body
+     * Serializes given object to json string to be used as a request body.
      *
      * @param t is an object to be serialized to json string
      * @param builder is used for the serialization
@@ -153,13 +152,14 @@ public final class CommonBodyPublishers {
      * @return a BodyPublisher
      */
     public static  <T> HttpRequest.BodyPublisher jsonStringBody(T t, GsonBuilder builder, Charset charset) {
+        checkArgument(nonNull(t), "Object to be serialized should not be a null value");
         checkArgument(nonNull(builder), "Json builder should not be a null value");
         checkArgument(nonNull(charset), "Char set should not be a null value");
         return ofString(builder.create().toJson(t), charset);
     }
 
     /**
-     * Serializes given object to json string for the using it as a request body
+     * Serializes given object to json string to be used as a request body.
      *
      * @param t is an object to be serialized to json string
      * @param builder is used for the serialization
@@ -171,8 +171,8 @@ public final class CommonBodyPublishers {
     }
 
     /**
-     * Serializes given object to json/xml string for the using it as a request body. The serializing is
-     * performed by Jackson
+     * Serializes given object to json/xml string to be used as a request body.
+     * A serialization is performed by Jackson.
      *
      * @param t is an object to be serialized to json string
      * @param mapper is an object mapper
@@ -192,8 +192,8 @@ public final class CommonBodyPublishers {
     }
 
     /**
-     * Serializes given object to json/xml string for the using it as a request body. The serializing is
-     * performed by Jackson
+     * Serializes given object to json/xml string to be used as a request body.
+     * A serialization is performed by Jackson.
      *
      * @param t is an object to be serialized to json string
      * @param mapper is an object mapper
@@ -212,7 +212,7 @@ public final class CommonBodyPublishers {
      * @param charset of a resulted request body
      * @return a BodyPublisher
      */
-    public static  HttpRequest.BodyPublisher documentStringBody(Document document,
+    public static  HttpRequest.BodyPublisher documentStringBody(org.w3c.dom.Document document,
                                                                 Transformer transformer,
                                                                 Charset charset) {
         checkArgument(nonNull(document), "Document should not be a null value");
@@ -238,7 +238,7 @@ public final class CommonBodyPublishers {
      * @param transformer is a transformer of the document to string value
      * @return a BodyPublisher
      */
-    public static HttpRequest.BodyPublisher documentStringBody(Document document, Transformer transformer) {
+    public static HttpRequest.BodyPublisher documentStringBody(org.w3c.dom.Document document, Transformer transformer) {
         return documentStringBody(document, transformer, UTF_8);
     }
 
@@ -267,7 +267,7 @@ public final class CommonBodyPublishers {
     }
 
     /**
-     * Transforms a map to to string body of {@code application/x-www-form-urlencoded} format
+     * Transforms a map to string body of {@code application/x-www-form-urlencoded} format
      *
      * @param formParameters is a map where keys are parameter names and values are values of defined parameters
      * @param charset of a resulted request body
@@ -291,7 +291,7 @@ public final class CommonBodyPublishers {
     }
 
     /**
-     * Transforms a map to to string body of {@code application/x-www-form-urlencoded} format
+     * Transforms a map to string body of {@code application/x-www-form-urlencoded} format
      *
      * @param formParameters is a map where keys are parameter names and values are values of defined parameters
      * @return a BodyPublisher

--- a/http.api/src/main/java/ru/tinkoff/qa/neptune/http/api/CommonBodyPublishers.java
+++ b/http.api/src/main/java/ru/tinkoff/qa/neptune/http/api/CommonBodyPublishers.java
@@ -17,12 +17,15 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.String.format;
 import static java.net.http.HttpRequest.BodyPublishers.*;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.nonNull;
+import static java.util.stream.Collectors.joining;
 
 /**
  * Creates instances if {@link java.net.http.HttpRequest.BodyPublisher} for more comfort usage
@@ -259,5 +262,35 @@ public final class CommonBodyPublishers {
      */
     public static  HttpRequest.BodyPublisher documentStringBody(org.jsoup.nodes.Document document) {
         return documentStringBody(document, UTF_8);
+    }
+
+    /**
+     * Transforms a map to to string body of a request. It is expected that keys of a map are parameter names
+     * and values are values of defined parameters. Resulted string body looks like following string
+     * {@code key1=val1&key2=val2}
+     *
+     * @param formParameters is a map where keys are parameter names and values are values of defined parameters
+     * @param charset of a resulted request body
+     * @return a BodyPublisher
+     */
+    public static HttpRequest.BodyPublisher formUrlEncodedStringParamsBody(Map<String, String> formParameters, Charset charset) {
+        checkArgument(nonNull(formParameters), "Form parameters should not be a null value");
+        checkArgument(formParameters.size() > 0, "Should be defined at least one parameter name and its value");
+        return ofString(formParameters.entrySet()
+                .stream()
+                .map(entry -> format("%s=%s", entry.getKey(), entry.getValue()))
+                .collect(joining("&")), charset);
+    }
+
+    /**
+     * Transforms a map to to string body of a request. It is expected that keys of a map are parameter names
+     * and values are values of defined parameters. Resulted string body looks like following string
+     * {@code key1=val1&key2=val2}
+     *
+     * @param formParameters is a map where keys are parameter names and values are values of defined parameters
+     * @return a BodyPublisher
+     */
+    public static HttpRequest.BodyPublisher formUrlEncodedStringParamsBody(Map<String, String> formParameters) {
+        return formUrlEncodedStringParamsBody(formParameters,  UTF_8);
     }
 }

--- a/http.api/src/main/java/ru/tinkoff/qa/neptune/http/api/response/body/data/FromJson.java
+++ b/http.api/src/main/java/ru/tinkoff/qa/neptune/http/api/response/body/data/FromJson.java
@@ -8,8 +8,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.nonNull;
 
 /**
- *
- * @param <T>
+ * This function is designed to deserialize json string to some object/array of custom objects. Deserialization is
+ * performed by {@link com.google.gson.Gson}
+ * @param <T> is a type of resulted object
  */
 public class FromJson<T> implements Function<String, T> {
 
@@ -24,23 +25,25 @@ public class FromJson<T> implements Function<String, T> {
     }
 
     /**
+     * Creates an instance of {@link FromJson}
      *
-     * @param toReturn
-     * @param builder
-     * @param <T>
-     * @return
+     * @param toReturn is a type of resulted object to deserialize string body of an http response
+     * @param builder is an instance of {@link GsonBuilder}
+     * @param <T> is a type of resulted object
+     * @return instance of {@link FromJson}
      */
-    public static <T> FromJson<T> getFromJson(Class<T> toReturn, GsonBuilder builder) {
+    public static <T> Function<String, T> getFromJson(Class<T> toReturn, GsonBuilder builder) {
         return new FromJson<>(toReturn, builder);
     }
 
     /**
+     * Creates an instance of {@link FromJson}
      *
-     * @param toReturn
-     * @param <T>
-     * @return
+     * @param toReturn is a type of resulted object to deserialize string body of an http response
+     * @param <T> is a type of resulted object
+     * @return instance of {@link FromJson}
      */
-    public static <T> FromJson<T> getFromJson(Class<T> toReturn) {
+    public static <T> Function<String, T> getFromJson(Class<T> toReturn) {
         return getFromJson(toReturn, new GsonBuilder());
     }
 

--- a/http.api/src/main/java/ru/tinkoff/qa/neptune/http/api/response/body/data/FromJson.java
+++ b/http.api/src/main/java/ru/tinkoff/qa/neptune/http/api/response/body/data/FromJson.java
@@ -1,0 +1,51 @@
+package ru.tinkoff.qa.neptune.http.api.response.body.data;
+
+import com.google.gson.GsonBuilder;
+
+import java.util.function.Function;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.nonNull;
+
+/**
+ *
+ * @param <T>
+ */
+public class FromJson<T> implements Function<String, T> {
+
+    private final Class<T> toGet;
+    private final GsonBuilder builder;
+
+    private FromJson(Class<T> toGet, GsonBuilder builder) {
+        checkArgument(nonNull(toGet), "Class of an object to get from json string should not be a null value");
+        checkArgument(nonNull(builder), "Builder should not be a null value");
+        this.builder = builder;
+        this.toGet = toGet;
+    }
+
+    /**
+     *
+     * @param toReturn
+     * @param builder
+     * @param <T>
+     * @return
+     */
+    public static <T> FromJson<T> getFromJson(Class<T> toReturn, GsonBuilder builder) {
+        return new FromJson<>(toReturn, builder);
+    }
+
+    /**
+     *
+     * @param toReturn
+     * @param <T>
+     * @return
+     */
+    public static <T> FromJson<T> getFromJson(Class<T> toReturn) {
+        return getFromJson(toReturn, new GsonBuilder());
+    }
+
+    @Override
+    public T apply(String s) {
+        return builder.create().fromJson(s, toGet);
+    }
+}

--- a/http.api/src/main/java/ru/tinkoff/qa/neptune/http/api/response/body/data/GetDocument.java
+++ b/http.api/src/main/java/ru/tinkoff/qa/neptune/http/api/response/body/data/GetDocument.java
@@ -12,17 +12,17 @@ import static java.util.Objects.nonNull;
 import static org.jsoup.Jsoup.parse;
 
 /**
- *
- * @param <T>
+ * This function is designed to read string content and transform it to XML/HTML documents.
+ * @param <T> is a type of resulted object
  */
 public abstract class GetDocument<T> implements Function<String, T> {
 
     /**
-     *
-     * @param documentBuilder
-     * @return
+     * Creates an instance of {@link GetDocument} that reads string body of a response and transforms it to {@link Document}
+     * @param documentBuilder an instance of that {@link DocumentBuilder} parses string and creates resulted xml/html document
+     * @return an instance of anonymous {@link GetDocument} subclass
      */
-    public static GetDocument<Document> getDocument(DocumentBuilder documentBuilder) {
+    public static Function<String, Document> getDocument(DocumentBuilder documentBuilder) {
         checkArgument(nonNull(documentBuilder), "Document builder should not be a null value");
         return new GetDocument<>() {
             @Override
@@ -38,10 +38,11 @@ public abstract class GetDocument<T> implements Function<String, T> {
     }
 
     /**
+     * Creates an instance of {@link GetDocument} that reads string body of a response and transforms it to {@link org.jsoup.nodes.Document}
      *
-     * @return
+     * @return an instance of anonymous {@link GetDocument} subclass
      */
-    public static GetDocument<org.jsoup.nodes.Document> getDocument() {
+    public static Function<String, org.jsoup.nodes.Document> getDocument() {
         return new GetDocument<>() {
             @Override
             public org.jsoup.nodes.Document apply(String s) {

--- a/http.api/src/main/java/ru/tinkoff/qa/neptune/http/api/response/body/data/GetDocument.java
+++ b/http.api/src/main/java/ru/tinkoff/qa/neptune/http/api/response/body/data/GetDocument.java
@@ -22,7 +22,7 @@ public abstract class GetDocument<T> implements Function<String, T> {
      * @param documentBuilder an instance of that {@link DocumentBuilder} parses string and creates resulted xml/html document
      * @return an instance of anonymous {@link GetDocument} subclass
      */
-    public static Function<String, Document> getDocument(DocumentBuilder documentBuilder) {
+    public static Function<String, org.w3c.dom.Document> getDocument(DocumentBuilder documentBuilder) {
         checkArgument(nonNull(documentBuilder), "Document builder should not be a null value");
         return new GetDocument<>() {
             @Override

--- a/http.api/src/main/java/ru/tinkoff/qa/neptune/http/api/response/body/data/GetDocument.java
+++ b/http.api/src/main/java/ru/tinkoff/qa/neptune/http/api/response/body/data/GetDocument.java
@@ -1,0 +1,52 @@
+package ru.tinkoff.qa.neptune.http.api.response.body.data;
+
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+
+import javax.xml.parsers.DocumentBuilder;
+import java.io.StringReader;
+import java.util.function.Function;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.nonNull;
+import static org.jsoup.Jsoup.parse;
+
+/**
+ *
+ * @param <T>
+ */
+public abstract class GetDocument<T> implements Function<String, T> {
+
+    /**
+     *
+     * @param documentBuilder
+     * @return
+     */
+    public static GetDocument<Document> getDocument(DocumentBuilder documentBuilder) {
+        checkArgument(nonNull(documentBuilder), "Document builder should not be a null value");
+        return new GetDocument<>() {
+            @Override
+            public Document apply(String s) {
+                var inputSource = new InputSource(new StringReader(s));
+                try {
+                    return documentBuilder.parse(inputSource);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+    }
+
+    /**
+     *
+     * @return
+     */
+    public static GetDocument<org.jsoup.nodes.Document> getDocument() {
+        return new GetDocument<>() {
+            @Override
+            public org.jsoup.nodes.Document apply(String s) {
+                return parse(s);
+            }
+        };
+    }
+}

--- a/http.api/src/main/java/ru/tinkoff/qa/neptune/http/api/response/body/data/GetMapped.java
+++ b/http.api/src/main/java/ru/tinkoff/qa/neptune/http/api/response/body/data/GetMapped.java
@@ -1,0 +1,61 @@
+package ru.tinkoff.qa.neptune.http.api.response.body.data;
+
+import java.util.function.Function;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.nonNull;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+/**
+ *
+ * @param <T>
+ */
+public class GetMapped<T> implements Function<String, T> {
+
+    private final Class<T> toGet;
+    private final ObjectMapper mapper;
+
+    private GetMapped(Class<T> toGet, ObjectMapper mapper) {
+        checkArgument(nonNull(toGet), "Class of an object to get should not be a null value");
+        checkArgument(nonNull(mapper), "Mapper should not be a null value");
+        this.toGet = toGet;
+        this.mapper = mapper;
+    }
+
+    /**
+     * @param toReturn
+     * @param mapper
+     * @param <T>
+     * @return
+     */
+    public static <T> GetMapped<T> getMapped(Class<T> toReturn, ObjectMapper mapper) {
+        return new GetMapped<>(toReturn, mapper);
+    }
+
+    /**
+     * 
+     * @param toReturn
+     * @param <T>
+     * @return
+     */
+    public static <T> GetMapped<T> getMapped(Class<T> toReturn) {
+        return getMapped(toReturn, new ObjectMapper());
+    }
+
+    @Override
+    public T apply(String s) {
+        try {
+            if (!isBlank(s)) {
+                return mapper.readValue(s, toGet);
+            }
+            else {
+                return null;
+            }
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/http.api/src/main/java/ru/tinkoff/qa/neptune/http/api/response/body/data/GetMapped.java
+++ b/http.api/src/main/java/ru/tinkoff/qa/neptune/http/api/response/body/data/GetMapped.java
@@ -1,13 +1,13 @@
 package ru.tinkoff.qa.neptune.http.api.response.body.data;
 
-import java.util.function.Function;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.util.function.Function;
+
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.nonNull;
-import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 /**
  * This function is designed to deserialize json/xml string to some object. Deserialization is
@@ -52,7 +52,7 @@ public class GetMapped<T> implements Function<String, T> {
     @Override
     public T apply(String s) {
         try {
-            if (!isBlank(s)) {
+            if (isNotBlank(s)) {
                 return mapper.readValue(s, toGet);
             }
             else {

--- a/http.api/src/main/java/ru/tinkoff/qa/neptune/http/api/response/body/data/GetMapped.java
+++ b/http.api/src/main/java/ru/tinkoff/qa/neptune/http/api/response/body/data/GetMapped.java
@@ -10,8 +10,9 @@ import static java.util.Objects.nonNull;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 /**
- *
- * @param <T>
+ * This function is designed to deserialize json/xml string to some object. Deserialization is
+ * performed by {@link com.fasterxml.jackson.databind.ObjectMapper}
+ * @param <T> is a type of resulted object
  */
 public class GetMapped<T> implements Function<String, T> {
 
@@ -26,22 +27,25 @@ public class GetMapped<T> implements Function<String, T> {
     }
 
     /**
-     * @param toReturn
-     * @param mapper
-     * @param <T>
-     * @return
+     * Creates an instance of {@link GetMapped}
+     *
+     * @param toReturn is a type of resulted object to deserialize string body of an http response
+     * @param mapper is an instance of {@link ObjectMapper}
+     * @param <T> is a type of resulted object
+     * @return instance of {@link GetMapped}
      */
-    public static <T> GetMapped<T> getMapped(Class<T> toReturn, ObjectMapper mapper) {
+    public static <T> Function<String, T> getMapped(Class<T> toReturn, ObjectMapper mapper) {
         return new GetMapped<>(toReturn, mapper);
     }
 
     /**
-     * 
-     * @param toReturn
-     * @param <T>
-     * @return
+     * Creates an instance of {@link GetMapped}
+     *
+     * @param toReturn is a type of resulted object to deserialize string body of an http response
+     * @param <T> is a type of resulted object
+     * @return instance of {@link GetMapped}
      */
-    public static <T> GetMapped<T> getMapped(Class<T> toReturn) {
+    public static <T> Function<String, T> getMapped(Class<T> toReturn) {
         return getMapped(toReturn, new ObjectMapper());
     }
 

--- a/http.api/src/test/java/ru/tinkoff/qa/neptune/http/api/test/BaseHttpTest.java
+++ b/http.api/src/test/java/ru/tinkoff/qa/neptune/http/api/test/BaseHttpTest.java
@@ -2,7 +2,9 @@ package ru.tinkoff.qa.neptune.http.api.test;
 
 import org.mockserver.client.MockServerClient;
 import org.mockserver.integration.ClientAndServer;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeSuite;
 
 import static java.util.Optional.ofNullable;
@@ -14,16 +16,10 @@ public class BaseHttpTest {
 
     static final String DOMAIN = "http://127.0.0.1";
     static final String REQUEST_URI = DOMAIN + ":1080";
-    static ClientAndServer clientAndServer;
+    static ClientAndServer clientAndServer = startClientAndServer(1080);
 
-    @BeforeSuite
-    public static void beforeSuite() {
-        clientAndServer = startClientAndServer(1080);
+    @BeforeClass
+    public static void preparation() {
         DO_CAPTURES_OF_INSTANCE.accept(SUCCESS_AND_FAILURE.name());
-    }
-
-    @AfterSuite
-    public static void afterSuite() {
-        ofNullable(clientAndServer).ifPresent(MockServerClient::stop);
     }
 }

--- a/http.api/src/test/java/ru/tinkoff/qa/neptune/http/api/test/CustomRequestBodyTest.java
+++ b/http.api/src/test/java/ru/tinkoff/qa/neptune/http/api/test/CustomRequestBodyTest.java
@@ -85,8 +85,7 @@ public class CustomRequestBodyTest extends BaseHttpTest {
                 request()
                         .withMethod("POST")
                         .withHeader("Content-Type", "application/json")
-                        .withBody(REQUEST_BODY_GSON
-                        )
+                        .withBody(REQUEST_BODY_GSON)
                         .withPath(PATH_TO_GSON))
                 .respond(response().withBody(JSON_HAS_BEEN_SUCCESSFULLY_POSTED));
 

--- a/http.api/src/test/java/ru/tinkoff/qa/neptune/http/api/test/CustomRequestBodyTest.java
+++ b/http.api/src/test/java/ru/tinkoff/qa/neptune/http/api/test/CustomRequestBodyTest.java
@@ -70,6 +70,7 @@ public class CustomRequestBodyTest extends BaseHttpTest {
             "</html>";
 
     private static final String REQUEST_BODY_URL_UNLOADED = "param1=value1&param2=value2";
+    private static final String REQUEST_BODY_URL_UNLOADED2 = "chip%26dale=rescue+rangers&how+to+get+water=2H2+%2B+O2+%3D+2H2O";
 
     private static final String JSON_HAS_BEEN_SUCCESSFULLY_POSTED = "Json has been successfully posted";
     private static final String JACKSON_XML_HAS_BEEN_SUCCESSFULLY_POSTED = "Jackson xml has been successfully posted";
@@ -120,6 +121,14 @@ public class CustomRequestBodyTest extends BaseHttpTest {
                         .withBody(REQUEST_BODY_URL_UNLOADED)
                         .withPath(PATH_URL_UNLOADED))
                 .respond(response().withBody(FORM_HAS_BEEN_SUCCESSFULLY_POSTED));
+
+        clientAndServer.when(
+                request()
+                        .withMethod("POST")
+                        .withHeader("Content-Type", "application/x-www-form-urlencoded")
+                        .withBody(REQUEST_BODY_URL_UNLOADED2)
+                        .withPath(PATH_URL_UNLOADED))
+                .respond(response().withBody(FORM_HAS_BEEN_SUCCESSFULLY_POSTED));
     }
 
     @DataProvider
@@ -134,6 +143,10 @@ public class CustomRequestBodyTest extends BaseHttpTest {
         var params = new LinkedHashMap<String, String>();
         params.put("param1", "value1");
         params.put("param2", "value2");
+
+        var params2 = new LinkedHashMap<String, String>();
+        params2.put("chip&dale", "rescue rangers");
+        params2.put("how to get water", "2H2 + O2 = 2H2O");
 
         var htmlDoc = Jsoup.parse("<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">\n" +
                 "<html>\n" +
@@ -176,6 +189,11 @@ public class CustomRequestBodyTest extends BaseHttpTest {
 
                 {PATH_URL_UNLOADED,
                         formUrlEncodedStringParamsBody(params),
+                        "application/x-www-form-urlencoded",
+                        FORM_HAS_BEEN_SUCCESSFULLY_POSTED},
+
+                {PATH_URL_UNLOADED,
+                        formUrlEncodedStringParamsBody(params2),
                         "application/x-www-form-urlencoded",
                         FORM_HAS_BEEN_SUCCESSFULLY_POSTED},
         };

--- a/http.api/src/test/java/ru/tinkoff/qa/neptune/http/api/test/CustomRequestBodyTest.java
+++ b/http.api/src/test/java/ru/tinkoff/qa/neptune/http/api/test/CustomRequestBodyTest.java
@@ -1,0 +1,179 @@
+package ru.tinkoff.qa.neptune.http.api.test;
+
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
+import com.google.gson.GsonBuilder;
+import org.jsoup.Jsoup;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.xml.sax.InputSource;
+import ru.tinkoff.qa.neptune.http.api.HttpStepContext;
+import ru.tinkoff.qa.neptune.http.api.test.request.body.BodyObject;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.TransformerFactory;
+import java.io.StringReader;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static java.net.http.HttpResponse.BodyHandlers.ofString;
+import static java.util.Map.entry;
+import static java.util.Map.ofEntries;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+import static ru.tinkoff.qa.neptune.core.api.steps.proxy.ProxyFactory.getProxied;
+import static ru.tinkoff.qa.neptune.http.api.CommonBodyPublishers.*;
+import static ru.tinkoff.qa.neptune.http.api.HttpResponseInfoSequentialGetSupplier.bodyOf;
+import static ru.tinkoff.qa.neptune.http.api.HttpResponseSequentialGetSupplier.responseOf;
+import static ru.tinkoff.qa.neptune.http.api.PreparedHttpRequest.POST;
+
+public class CustomRequestBodyTest extends BaseHttpTest {
+
+    private HttpStepContext httpSteps = getProxied(HttpStepContext.class);
+
+    private static final BodyObject BODY_OBJECT = new BodyObject().setA("Some String")
+            .setB(666)
+            .setC(true);
+
+    @BeforeClass
+    public static void beforeClass() {
+        clientAndServer.when(
+                request()
+                        .withMethod("POST")
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"A\":\"Some String\",\"B\":666,\"C\":true}")
+                        .withPath("/gson"))
+                .respond(response().withBody("Json has been successfully posted"));
+
+        clientAndServer.when(
+                request()
+                        .withMethod("POST")
+                        .withHeader("Content-Type", "application/xml")
+                        .withBody("<BodyObject><wstxns1:A1 xmlns:wstxns1=\"http://www.test.com\">Some String</wstxns1:A1><wstxns2:B1 xmlns:wstxns2=\"http://www.test.com\">666</wstxns2:B1><wstxns3:C1 xmlns:wstxns3=\"http://www.test.com\">true</wstxns3:C1></BodyObject>")
+                        .withPath("/jackson_xml"))
+                .respond(response().withBody("Jackson xml has been successfully posted"));
+
+        clientAndServer.when(
+                request()
+                        .withMethod("POST")
+                        .withHeader("Content-Type", "application/xml")
+                        .withBody("<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?><a><b/><c/></a>")
+                        .withPath("/document_xml"))
+                .respond(response().withBody("Document xml has been successfully posted"));
+
+        clientAndServer.when(
+                request()
+                        .withMethod("POST")
+                        .withHeader("Content-Type", "multipart/form-data")
+                        .withBody("<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">\n" +
+                                "<html>\n" +
+                                " <head> \n" +
+                                "  <meta http-equiv=\"Content-Type\" content=\"text/html; charset=ISO-8859-1\"> \n" +
+                                "  <title>Login Page</title> \n" +
+                                " </head> \n" +
+                                " <body> \n" +
+                                "  <div id=\"login\" class=\"simple\"> \n" +
+                                "   <form action=\"login.do\">\n" +
+                                "     Username : \n" +
+                                "    <input id=\"username\" type=\"text\">\n" +
+                                "    <br> Password : \n" +
+                                "    <input id=\"password\" type=\"password\">\n" +
+                                "    <br> \n" +
+                                "    <input id=\"submit\" type=\"submit\"> \n" +
+                                "    <input id=\"reset\" type=\"reset\"> \n" +
+                                "   </form> \n" +
+                                "  </div>  \n" +
+                                " </body>\n" +
+                                "</html>")
+                        .withPath("/document_html"))
+                .respond(response().withBody("Document html has been successfully posted"));
+
+        clientAndServer.when(
+                request()
+                        .withMethod("POST")
+                        .withHeader("Content-Type", "application/x-www-form-urlencoded")
+                        .withBody("param1=value1&param2=value2")
+                        .withPath("/urlencoded"))
+                .respond(response().withBody("Form has been successfully posted"));
+    }
+
+    @Test
+    public void ofGsonBodyTest() {
+        assertThat(httpSteps.get(bodyOf(responseOf(
+                POST(REQUEST_URI + "/gson",
+                        jsonStringBody(BODY_OBJECT, new GsonBuilder()))
+                        .header("Content-Type", "application/json"),
+                ofString()))),
+                is("Json has been successfully posted"));
+    }
+
+    @Test
+    public void testOfXmlMappedBodyTest() {
+        JaxbAnnotationModule module = new JaxbAnnotationModule();
+        assertThat(httpSteps.get(bodyOf(responseOf(
+                POST(REQUEST_URI + "/jackson_xml",
+                        serializedStringBody(BODY_OBJECT, new XmlMapper().registerModule(module)))
+                        .header("Content-Type", "application/xml"),
+                ofString()))),
+                is("Jackson xml has been successfully posted"));
+    }
+
+    @Test
+    public void ofXmlDocumentBodyTest() throws Exception {
+        var documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        var documentBuilder = documentBuilderFactory.newDocumentBuilder();
+        var inputSource = new InputSource(new StringReader("<?xml version=\"1.0\" encoding=\"utf-8\"?><a><b></b><c></c></a>"));
+        var doc = documentBuilder.parse(inputSource);
+
+        assertThat(httpSteps.get(bodyOf(responseOf(
+                POST(REQUEST_URI + "/document_xml",
+                        documentStringBody(doc, TransformerFactory.newInstance().newTransformer()))
+                        .header("Content-Type", "application/xml"),
+                ofString()))),
+                is("Document xml has been successfully posted"));
+    }
+
+    @Test
+    public void ofHtmlDocumentBodyTest() {
+        var doc = Jsoup.parse("<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">\n" +
+                "<html>\n" +
+                "    <head>\n" +
+                "        <meta http-equiv=\"Content-Type\" content=\"text/html; charset=ISO-8859-1\">\n" +
+                "        <title>Login Page</title>\n" +
+                "    </head>\n" +
+                "    <body>\n" +
+                "        <div id=\"login\" class=\"simple\" >\n" +
+                "            <form action=\"login.do\">\n" +
+                "                Username : <input id=\"username\" type=\"text\" /><br>\n" +
+                "                Password : <input id=\"password\" type=\"password\" /><br>\n" +
+                "                <input id=\"submit\" type=\"submit\" />\n" +
+                "                <input id=\"reset\" type=\"reset\" />\n" +
+                "            </form>\n" +
+                "        </div>\n" +
+                "    </body>\n" +
+                "</html>");
+
+        assertThat(httpSteps.get(bodyOf(responseOf(
+                POST(REQUEST_URI + "/document_html",
+                        documentStringBody(doc))
+                        .header("Content-Type", "multipart/form-data"),
+                ofString()))),
+                is("Document html has been successfully posted"));
+    }
+
+    @Test
+    public void ofFormUrlEncodedStringParamsBodyTest() {
+        var params = new LinkedHashMap<String, String>();
+        params.put("param1", "value1");
+        params.put("param2", "value2");
+
+        assertThat(httpSteps.get(bodyOf(responseOf(
+                POST(REQUEST_URI + "/urlencoded",
+                        formUrlEncodedStringParamsBody(params))
+                        .header("Content-Type", "application/x-www-form-urlencoded"),
+                ofString()))),
+                is("Form has been successfully posted"));
+    }
+}

--- a/http.api/src/test/java/ru/tinkoff/qa/neptune/http/api/test/CustomResponseBodyTest.java
+++ b/http.api/src/test/java/ru/tinkoff/qa/neptune/http/api/test/CustomResponseBodyTest.java
@@ -1,0 +1,145 @@
+package ru.tinkoff.qa.neptune.http.api.test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
+import org.hamcrest.Matcher;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.w3c.dom.Document;
+import ru.tinkoff.qa.neptune.http.api.HttpStepContext;
+import ru.tinkoff.qa.neptune.http.api.test.request.body.BodyObject;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.util.function.Function;
+
+import static java.net.http.HttpResponse.BodyHandlers.ofString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+import static ru.tinkoff.qa.neptune.core.api.steps.proxy.ProxyFactory.getProxied;
+import static ru.tinkoff.qa.neptune.http.api.HttpGetObjectFromResponseBody.bodyDataOf;
+import static ru.tinkoff.qa.neptune.http.api.HttpResponseSequentialGetSupplier.responseOf;
+import static ru.tinkoff.qa.neptune.http.api.PreparedHttpRequest.GET;
+import static ru.tinkoff.qa.neptune.http.api.response.body.data.FromJson.getFromJson;
+import static ru.tinkoff.qa.neptune.http.api.response.body.data.GetDocument.getDocument;
+import static ru.tinkoff.qa.neptune.http.api.response.body.data.GetMapped.getMapped;
+
+public class CustomResponseBodyTest extends BaseHttpTest {
+
+    private HttpStepContext httpSteps = getProxied(HttpStepContext.class);
+
+    private static final BodyObject BODY_OBJECT = new BodyObject().setA("Some String 2")
+            .setB(777)
+            .setC(false);
+
+    private static final String RESPONSE_GSON = "{\"A\":\"Some String 2\",\"B\":777,\"C\":false}";
+    private static final String RESPONSE_MAPPED = "<BodyObject><wstxns1:A1 xmlns:wstxns1=\"http://www.test.com\">Some String 2</wstxns1:A1>" +
+            "<wstxns2:B1 xmlns:wstxns2=\"http://www.test.com\">777</wstxns2:B1>" +
+            "<wstxns3:C1 xmlns:wstxns3=\"http://www.test.com\">false</wstxns3:C1></BodyObject>";
+
+    private static final String XML_FOR_DOCUMENT = "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?><a><b/><c/></a>";
+    private static final String HTML_FOR_DOCUMENT = "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">\n" +
+            "<html>\n" +
+            "    <head>\n" +
+            "        <meta http-equiv=\"Content-Type\" content=\"text/html; charset=ISO-8859-1\">\n" +
+            "        <title>Login Page</title>\n" +
+            "    </head>\n" +
+            "    <body>\n" +
+            "        <div id=\"login\" class=\"simple\" >\n" +
+            "            <form action=\"login.do\">\n" +
+            "                Username : <input id=\"username\" type=\"text\" /><br>\n" +
+            "                Password : <input id=\"password\" type=\"password\" /><br>\n" +
+            "                <input id=\"submit\" type=\"submit\" />\n" +
+            "                <input id=\"reset\" type=\"reset\" />\n" +
+            "            </form>\n" +
+            "        </div>\n" +
+            "    </body>\n" +
+            "</html>";
+
+    private static final String PATH_TO_GSON = "/gson";
+    private static final String PATH_TO_JACKSON = "/jackson_xml";
+    private static final String PATH_DOCUMENT_XML = "/document_xml";
+    private static final String PATH_DOCUMENT_HTML = "/document_html";
+
+    private static ObjectMapper mapper;
+    private static DocumentBuilder documentBuilder;
+
+    @BeforeClass
+    public static void prepareMock() {
+        clientAndServer.when(
+                request()
+                        .withMethod("GET")
+                        .withPath(PATH_TO_GSON))
+                .respond(response().withBody(RESPONSE_GSON));
+
+        clientAndServer.when(
+                request()
+                        .withMethod("GET")
+                        .withPath(PATH_TO_JACKSON))
+                .respond(response().withBody(RESPONSE_MAPPED));
+
+        clientAndServer.when(
+                request()
+                        .withMethod("GET")
+                        .withPath(PATH_DOCUMENT_XML))
+                .respond(response().withBody(XML_FOR_DOCUMENT));
+
+        clientAndServer.when(
+                request()
+                        .withMethod("GET")
+                        .withPath(PATH_DOCUMENT_HTML))
+                .respond(response().withBody(HTML_FOR_DOCUMENT));
+    }
+
+    @BeforeClass
+    public static void prepareExpectedResults() throws Exception {
+        var documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        documentBuilder = documentBuilderFactory.newDocumentBuilder();
+
+        var module = new JaxbAnnotationModule();
+        mapper =  new XmlMapper().registerModule(module);
+    }
+
+    @DataProvider
+    public static Object[][] data() {
+        return new Object[][] {
+                {PATH_TO_GSON,
+                        "Object created by Gson",
+                        getFromJson(BodyObject.class),
+                        equalTo(BODY_OBJECT)},
+
+                {PATH_TO_JACKSON,
+                        "Object created by Jackson",
+                        getMapped(BodyObject.class, mapper),
+                        equalTo(BODY_OBJECT)},
+
+                {PATH_DOCUMENT_XML,
+                        "xml Document",
+                        getDocument(documentBuilder),
+                        instanceOf(Document.class)},
+
+                {PATH_DOCUMENT_HTML,
+                        "html Document",
+                        getDocument(),
+                        instanceOf(org.jsoup.nodes.Document.class)},
+        };
+    }
+
+    @Test(dataProvider = "data")
+    public void customResponseBodyTest(String urlPath,
+                                       String toGetDescription,
+                                       Function<String, ?> howToGet,
+                                       Matcher<? super  Object> matcher){
+        assertThat(httpSteps.get(bodyDataOf(responseOf(
+                GET(REQUEST_URI + urlPath),
+                ofString()),
+                toGetDescription,
+                howToGet)),
+                matcher);
+    }
+}

--- a/http.api/src/test/java/ru/tinkoff/qa/neptune/http/api/test/request/body/BodyObject.java
+++ b/http.api/src/test/java/ru/tinkoff/qa/neptune/http/api/test/request/body/BodyObject.java
@@ -5,6 +5,10 @@ import com.google.gson.annotations.SerializedName;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
 
+import java.util.Objects;
+
+import static java.util.Objects.nonNull;
+
 @XmlType(namespace = "http://www.example.com")
 public class BodyObject {
 
@@ -46,5 +50,13 @@ public class BodyObject {
     public BodyObject setC(Boolean c) {
         this.c = c;
         return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return nonNull(o) && BodyObject.class.equals(o.getClass())
+                && Objects.equals(this.a, ((BodyObject) o).a)
+                && Objects.equals(this.b, ((BodyObject) o).b)
+                && Objects.equals(this.c, ((BodyObject) o).c);
     }
 }

--- a/http.api/src/test/java/ru/tinkoff/qa/neptune/http/api/test/request/body/BodyObject.java
+++ b/http.api/src/test/java/ru/tinkoff/qa/neptune/http/api/test/request/body/BodyObject.java
@@ -1,0 +1,50 @@
+package ru.tinkoff.qa.neptune.http.api.test.request.body;
+
+import com.google.gson.annotations.SerializedName;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlType(namespace = "http://www.example.com")
+public class BodyObject {
+
+    @SerializedName("A")
+    @XmlElement(namespace = "http://www.test.com", name = "A1")
+    private String a;
+
+    @SerializedName("B")
+    @XmlElement(namespace = "http://www.test.com", name = "B1")
+    private Integer b;
+
+    @SerializedName("C")
+    @XmlElement(namespace = "http://www.test.com", name = "C1")
+    private Boolean c;
+
+    public String getA() {
+        return a;
+    }
+
+    public BodyObject setA(String a) {
+        this.a = a;
+        return this;
+    }
+
+
+    public Integer getB() {
+        return b;
+    }
+
+    public BodyObject setB(Integer b) {
+        this.b = b;
+        return this;
+    }
+
+    public Boolean getC() {
+        return c;
+    }
+
+    public BodyObject setC(Boolean c) {
+        this.c = c;
+        return this;
+    }
+}

--- a/selenium/build.gradle
+++ b/selenium/build.gradle
@@ -2,9 +2,10 @@ dependencies {
     compile project(':core.api')
     compile group: 'org.seleniumhq.selenium', name: 'selenium-java', version: seleniumVersion
     compile group: 'org.hamcrest', name: 'hamcrest', version: hamcrestVersion
-    compile (group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '3.6.2') {
+    compile (group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '3.7.0') {
         exclude group: 'org.seleniumhq.selenium'
         exclude group: 'org.apache.commons', module: 'commons-lang3'
+        exclude group: 'org.jsoup', module: 'jsoup'
     }
     compile (group: 'org.seleniumhq.selenium', name: 'selenium-server', version: seleniumVersion) {
         exclude group: 'org.seleniumhq.selenium', module: 'htmlunit-driver'
@@ -13,7 +14,8 @@ dependencies {
         exclude group: 'net.bytebuddy', module:'byte-buddy'
     }
     testCompile group: 'org.mockito', name: 'mockito-core', version: '2.23.4'
-    compile group: 'cglib', name: 'cglib', version: '3.2.12'
+    compile group: 'cglib', name: 'cglib', version: '3.3.0'
+    compile group: 'org.jsoup', name: 'jsoup', version: '1.12.1'
 }
 
 test {


### PR DESCRIPTION
Added: 
- new methods that turn objects to bodies of http POST/PUT requests by:
  - Gson
  - Jackson
  - Gsoup
  - tools from the `org.w3c.dom.*` package

- new functions that turn string values of http responses to objsects by:
  - Gson
  - Jackson
  - Gsoup
  - tools from the `org.w3c.dom.*` package

Also:
- dependency updates