### PR TITLE
Bug fix: URL/URI validation before action

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    globalVersion = '0.10.6-ALPHA'
+    globalVersion = '0.10.7-ALPHA'
 }
 
 subprojects {
@@ -44,7 +44,6 @@ subprojects {
         compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion
         compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-jaxb-annotations', version: jacksonVersion
         compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-xml', version: jacksonVersion
-        compile group: 'commons-validator', name: 'commons-validator', version: '1.6'
         compile group: 'commons-io', name: 'commons-io', version: '2.6'
         compile group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
     }


### PR DESCRIPTION
It is reproduced on browser navigation/http request sending by @AndrewCharykov 

### How to reproduce:

1. We have such URL as `http://web:150`. 
2. It is valid URL/URI actually. Attempth to create these objects are successful (see below):

```java
new URL("http://web:150");
new URI("http://web:150");
``` 
![Безымянный](https://user-images.githubusercontent.com/4927589/67966027-2c0b6300-fc14-11e9-99a8-56ce93023139.png)

3. When it tries to navigate in browser to this page/send http request to this endpoint it throws an exception about malformed address.

### The solution:

Root cause was here 
`compile group: 'commons-validator', name: 'commons-validator', version: '1.6'`

Code like that causes the failure

```java
new UrlValidator().isValid("http://web:150") //it returns `false`
```

As the library has been used only by 2 classes (where failures occure) so the dependency was removed and unstable code was simplified