### PR TITLE
Additional features and refactor. DB module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ cache:
 before_install:
   - # start your web application and listen on `localhost`
   - 'google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &'
-  - wget http://services.gradle.org/distributions/gradle-5.6.2-bin.zip
+  - wget https://services.gradle.org/distributions/gradle-5.6.2-bin.zip
   - unzip -qq gradle-5.6.2-bin.zip
   - export GRADLE_HOME=$PWD/gradle-5.6.2
   - export PATH=$GRADLE_HOME/bin:$PATH

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    globalVersion = '0.10.11-ALPHA'
+    globalVersion = '0.10.12-ALPHA'
 }
 
 subprojects {

--- a/data.base.api/build.gradle
+++ b/data.base.api/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     compile group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
     compile group: 'org.apache.ant', name: 'ant', version: '1.10.6'
     testCompile group: 'org.xerial', name: 'sqlite-jdbc', version: '3.28.0'
+    testCompile group: 'com.oracle.ojdbc', name: 'ojdbc8', version: '19.3.0.0'
     testAnnotationProcessor 'org.datanucleus:datanucleus-jdo-query:5.0.9'
     testAnnotationProcessor group: 'org.datanucleus', name: 'javax.jdo', version: '3.2.0-m12'
 }

--- a/data.base.api/src/main/java/ru/tinkoff/qa/neptune/data/base/api/queries/jdoql/JDOQLResultQueryParams.java
+++ b/data.base.api/src/main/java/ru/tinkoff/qa/neptune/data/base/api/queries/jdoql/JDOQLResultQueryParams.java
@@ -48,33 +48,17 @@ public class JDOQLResultQueryParams<T extends PersistableObject, Q extends Persi
         return new JDOQLResultQueryParams<>(toUse);
     }
 
-    /**
-     * Sets GROUP BY-clause to query. The sample below:
-     * <p>
-     * {@code byJDOQuery(QPerson.class)
-     *          .setGroupBy(qPerson -> qPerson.name)
-     * </p>
-     * @param expression is a function that returns a {@link Expression}
-     * @return self-reference
-     */
-    public JDOQLResultQueryParams<T, Q> setGroupBy(Function<Q, Expression<?>> expression) {
-        checkArgument(nonNull(expression), "GroupBy expressions should be defined as not a null value");
-        var groupBy = expression.apply(persistableExpression);
-        checkNotNull(groupBy);
-        this.groupByExpressions =  new Expression[] {groupBy};
-        return this;
-    }
 
     /**
      * Adds GROUP BY-clause to query. The sample below:
      * <p>
      * {@code byJDOQuery(QPerson.class)
-     *          .addGroupBy(qPerson -> qPerson.name)
+     *          .groupBy(qPerson -> qPerson.name)
      * </p>
      * @param expression is a function that returns a {@link Expression}
      * @return self-reference
      */
-    public JDOQLResultQueryParams<T, Q> addGroupBy(Function<Q, Expression<?>> expression) {
+    public JDOQLResultQueryParams<T, Q> groupBy(Function<Q, Expression<?>> expression) {
         checkArgument(nonNull(expression), "GroupBy expression should be defined as not a null value");
         var groupBy = expression.apply(persistableExpression);
         checkNotNull(groupBy);
@@ -102,34 +86,17 @@ public class JDOQLResultQueryParams<T extends PersistableObject, Q extends Persi
         return this;
     }
 
-    /**
-     * Sets result field to query. The sample below:
-     * <p>
-     * {@code byJDOQuery(QPerson.class)
-     *          .setResultField(qPerson -> qPerson.name)
-     * </p>
-     * @param expression is a function that returns a {@link Expression}
-     * @return self-reference
-     */
-    public JDOQLResultQueryParams<T, Q> setResultField(Function<Q, Expression<?>> expression) {
-        checkArgument(nonNull(expression), "Result field expression should be defined as not a null value");
-        var result = expression.apply(persistableExpression);
-        checkNotNull(result);
-        this.resultFields =  new Expression[] {result};
-        return this;
-    }
-
 
     /**
      * Adds result field to query. The sample below:
      * <p>
      * {@code byJDOQuery(QPerson.class)
-     *          .addResultField(qPerson -> qPerson.name)
+     *          .resultField(qPerson -> qPerson.name)
      * </p>
      * @param expression is a function that returns a {@link Expression}
      * @return self-reference
      */
-    public JDOQLResultQueryParams<T, Q> addResultField(Function<Q, Expression<?>> expression) {
+    public JDOQLResultQueryParams<T, Q> resultField(Function<Q, Expression<?>> expression) {
         checkArgument(nonNull(expression), "Result field expression should be defined as not a null value");
         var result = expression.apply(persistableExpression);
         checkNotNull(result);

--- a/data.base.api/src/main/java/ru/tinkoff/qa/neptune/data/base/api/queries/jdoql/WhereJunction.java
+++ b/data.base.api/src/main/java/ru/tinkoff/qa/neptune/data/base/api/queries/jdoql/WhereJunction.java
@@ -1,0 +1,69 @@
+package ru.tinkoff.qa.neptune.data.base.api.queries.jdoql;
+
+import org.datanucleus.api.jdo.query.BooleanExpressionImpl;
+import org.datanucleus.api.jdo.query.ExpressionImpl;
+import org.datanucleus.query.expression.DyadicExpression;
+import org.datanucleus.query.expression.Expression;
+
+import javax.jdo.query.BooleanExpression;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Optional.ofNullable;
+import static org.datanucleus.query.expression.Expression.OP_AND;
+import static org.datanucleus.query.expression.Expression.OP_OR;
+
+/**
+ * This is the utility class that helps to aggregate complex where-expressions
+ * by AND-/OR junctions.
+ */
+public final class WhereJunction {
+
+    private final Expression.DyadicOperator operator;
+
+    private WhereJunction(Expression.DyadicOperator operator) {
+        this.operator = operator;
+    }
+
+    /**
+     * Aggregates defined expressions by AND-junction
+     *
+     * @param expressions expressions to be junctioned.
+     * @return new {@link BooleanExpression}
+     */
+    public static BooleanExpression and(BooleanExpression... expressions) {
+        return new WhereJunction(OP_AND).getExpression(expressions);
+    }
+
+    /**
+     * Aggregates defined expressions by OR-junction
+     *
+     * @param expressions expressions to be junctioned.
+     * @return new {@link BooleanExpression}
+     */
+    public static BooleanExpression or(BooleanExpression... expressions) {
+        return new WhereJunction(OP_OR).getExpression(expressions);
+    }
+
+    private BooleanExpression getExpression(BooleanExpression... expressions) {
+        checkNotNull(expressions, "Expressions should be defined as a value that differs from null");
+        checkArgument(expressions.length >= 2, "At least 2 expression should be defined");
+
+        BooleanExpression resultExpression = null;
+
+        for (var be: expressions) {
+            resultExpression = ofNullable(resultExpression)
+                    .map(expr ->  {
+                        Expression leftQueryExpr = ((ExpressionImpl) expr).getQueryExpression();
+                        Expression rightQueryExpr = ((ExpressionImpl) be).getQueryExpression();
+
+                        org.datanucleus.query.expression.Expression queryExpr =
+                                new DyadicExpression(leftQueryExpr, operator, rightQueryExpr);
+                        return (BooleanExpression) new BooleanExpressionImpl(queryExpr);
+                    })
+                    .orElse(be);
+        }
+
+        return resultExpression;
+    }
+}

--- a/data.base.api/src/test/java/ru/tinkoff/qa/neptune/data/base/test/persistable/object/operations/select/SelectBySqlQuery.java
+++ b/data.base.api/src/test/java/ru/tinkoff/qa/neptune/data/base/test/persistable/object/operations/select/SelectBySqlQuery.java
@@ -35,7 +35,7 @@ public class SelectBySqlQuery extends BaseDbOperationTest {
 
         List<Book> books2 = dataBaseSteps.get(listOf(Book.class, byJDOQuery(QBook.class)
                 .where(qBook -> qBook.yearOfFinishing.gteq(1820))
-                .addOrderBy(qBook -> qBook.yearOfFinishing.asc())));
+                .orderBy(qBook -> qBook.yearOfFinishing.asc())));
 
         List<Author> authors2 = books2.stream().map(Book::getAuthor).collect(toList());
         assertThat(authors2, contains(authors.toArray()));
@@ -49,7 +49,7 @@ public class SelectBySqlQuery extends BaseDbOperationTest {
 
         Book book2 = dataBaseSteps.select(oneOf(Book.class, byJDOQuery(QBook.class)
                 .where(qBook -> qBook.yearOfFinishing.gteq(1820))
-                .addOrderBy(qBook -> qBook.yearOfFinishing.asc())));
+                .orderBy(qBook -> qBook.yearOfFinishing.asc())));
         Author author2 = book2.getAuthor();
 
         assertThat(author2, equalTo(author));
@@ -64,7 +64,7 @@ public class SelectBySqlQuery extends BaseDbOperationTest {
                 .subList(0, 1);
         List<Book> books = dataBaseSteps.select(listOf(Book.class, byJDOQuery(QBook.class)
                 .where(qBook -> qBook.yearOfFinishing.gteq(1820))
-                .addOrderBy(qBook -> qBook.yearOfFinishing.asc())
+                .orderBy(qBook -> qBook.yearOfFinishing.asc())
                 .range(0, 1)));
 
         List<List<Object>> booksAndAuthors2 = books.stream()

--- a/data.base.api/src/test/java/ru/tinkoff/qa/neptune/data/base/test/persistable/object/operations/select/SelectByTypedQuery.java
+++ b/data.base.api/src/test/java/ru/tinkoff/qa/neptune/data/base/test/persistable/object/operations/select/SelectByTypedQuery.java
@@ -27,6 +27,8 @@ import static ru.tinkoff.qa.neptune.data.base.api.queries.SelectList.listOf;
 import static ru.tinkoff.qa.neptune.data.base.api.queries.SelectList.rows;
 import static ru.tinkoff.qa.neptune.data.base.api.queries.jdoql.JDOQLQueryParameters.byJDOQuery;
 import static ru.tinkoff.qa.neptune.data.base.api.queries.jdoql.JDOQLResultQueryParams.byJDOResultQuery;
+import static ru.tinkoff.qa.neptune.data.base.api.queries.jdoql.WhereJunction.and;
+import static  ru.tinkoff.qa.neptune.data.base.api.queries.jdoql.WhereJunction.or;
 
 @SuppressWarnings("ConstantConditions")
 public class SelectByTypedQuery extends BaseDbOperationTest {
@@ -46,28 +48,34 @@ public class SelectByTypedQuery extends BaseDbOperationTest {
     @BeforeClass
     public void prepare() {
         carlosCastaneda = dataBaseSteps.select(oneOf(Author.class, byJDOQuery(QAuthor.class)
-                .where(qAuthor -> qAuthor.firstName.eq("Carlos").and(qAuthor.lastName.eq("Castaneda")))));
+                .where(qAuthor -> qAuthor.firstName.eq("Carlos"),
+                        qAuthor ->  qAuthor.lastName.eq("Castaneda"))));
 
         journeyToIxtlan = dataBaseSteps.select(oneOf(Book.class, byJDOQuery(QBook.class)
-                .where(qBook -> qBook.name.eq("Journey to Ixtlan").and(qBook.author.eq(carlosCastaneda)))));
+                .where(qBook -> qBook.name.eq("Journey to Ixtlan"),
+                        qBook -> qBook.author.eq(carlosCastaneda))));
 
         alexanderPushkin = dataBaseSteps.select(oneOf(Author.class, byJDOQuery(QAuthor.class)
-                .where(qAuthor -> qAuthor.firstName.eq("Alexander").and(qAuthor.lastName.eq("Pushkin")))));
+                .where(qAuthor -> qAuthor.firstName.eq("Alexander"),
+                        qAuthor -> qAuthor.lastName.eq("Pushkin"))));
 
         ruslanAndLudmila = dataBaseSteps.select(oneOf(Book.class, byJDOQuery(QBook.class)
-                .where(qBook -> qBook.name.eq("Ruslan and Ludmila").and(qBook.author.eq(alexanderPushkin)))));
+                .where(qBook -> qBook.name.eq("Ruslan and Ludmila"),
+                        qBook -> qBook.author.eq(alexanderPushkin))));
 
         theLegendOfTheAges = dataBaseSteps.select(oneOf(Book.class, byJDOQuery(QBook.class)
                 .where(qBook -> qBook.name.eq("The Legend of the Ages"))));
 
         hugo = dataBaseSteps.select(oneOf(Author.class, byJDOQuery(QAuthor.class)
-                .where(qAuthor -> qAuthor.firstName.eq("Victor").and(qAuthor.lastName.eq("Hugo")))));
+                .where(qAuthor -> qAuthor.firstName.eq("Victor"),
+                        qAuthor -> qAuthor.lastName.eq("Hugo"))));
 
         aHeroOfOurTimes = dataBaseSteps.select(oneOf(Book.class, byJDOQuery(QBook.class)
                 .where(qBook -> qBook.name.eq("A Hero of Our Times"))));
 
         lermontov = dataBaseSteps.select(oneOf(Author.class, byJDOQuery(QAuthor.class)
-                .where(qAuthor -> qAuthor.firstName.eq("Mikhail").and(qAuthor.lastName.eq("Lermontov")))));
+                .where(qAuthor -> qAuthor.firstName.eq("Mikhail"),
+                        qAuthor ->  qAuthor.lastName.eq("Lermontov"))));
     }
 
     @Test(groups = "positive tests")
@@ -85,9 +93,11 @@ public class SelectByTypedQuery extends BaseDbOperationTest {
     @Test(groups = "positive tests")
     public void selectListTestWithQuery() {
         var catalogItems = dataBaseSteps.select(listOf(Catalog.class, byJDOQuery(QCatalog.class)
-                .where(qCatalog -> qCatalog.book.name.eq(ruslanAndLudmila.getName())
-                        .or(qCatalog.book.author.lastName.eq(carlosCastaneda.getLastName())))
-                .addOrderBy(qCatalog -> qCatalog.book.id.desc())));
+                .where(qCatalog -> or(
+                        qCatalog.book.name.eq(ruslanAndLudmila.getName()),
+                        qCatalog.book.author.lastName.eq(carlosCastaneda.getLastName()))
+                )
+                .orderBy(qCatalog -> qCatalog.book.id.desc())));
 
         assertThat(catalogItems, hasSize(2));
         assertThat(catalogItems.stream().map(catalog -> catalog.getBook().getName()).collect(toList()),
@@ -97,11 +107,52 @@ public class SelectByTypedQuery extends BaseDbOperationTest {
     @Test(groups = "positive tests")
     public void selectOneTestWithQuery() {
         var catalogItem = dataBaseSteps.select(oneOf(Catalog.class, byJDOQuery(QCatalog.class)
-                .where(qCatalog -> qCatalog.book.name.eq(ruslanAndLudmila.getName())
-                        .or(qCatalog.book.author.lastName.eq(carlosCastaneda.getLastName())))
-                .addOrderBy(qCatalog -> qCatalog.book.id.desc())));
+                .where(qCatalog -> or(
+                        qCatalog.book.name.eq(ruslanAndLudmila.getName()),
+                        qCatalog.book.author.lastName.eq(carlosCastaneda.getLastName())
+                ))
+                .orderBy(qCatalog -> qCatalog.book.id.desc())));
 
         assertThat(catalogItem.getBook().getName(), is("Ruslan and Ludmila"));
+    }
+
+    @Test(groups = "positive tests")
+    public void selectOneTestWithWhereJunctionQuery() {
+        var catalogItem = dataBaseSteps.select(oneOf(Catalog.class, byJDOQuery(QCatalog.class)
+                .where(qCatalog -> or(
+                        and(
+                                qCatalog.book.name.eq(ruslanAndLudmila.getName()),
+                                qCatalog.book.author.lastName.eq(alexanderPushkin.getLastName())
+                        ),
+                        and(
+                                qCatalog.book.name.eq(journeyToIxtlan.getName()),
+                                qCatalog.book.author.lastName.eq(carlosCastaneda.getLastName())
+                        )
+
+                ))
+                .orderBy(qCatalog -> qCatalog.book.id.desc())));
+
+        assertThat(catalogItem.getBook().getName(), is("Ruslan and Ludmila"));
+    }
+
+    @Test(groups = "positive tests")
+    public void selectListTestWithWithWhereJunctionQuery() {
+        var catalogItems = dataBaseSteps.select(listOf(Catalog.class, byJDOQuery(QCatalog.class)
+                .where(qCatalog -> or(
+                        and(
+                                qCatalog.book.name.eq(ruslanAndLudmila.getName()),
+                                qCatalog.book.author.lastName.eq(alexanderPushkin.getLastName())
+                        ),
+                        and(
+                                qCatalog.book.name.eq(journeyToIxtlan.getName()),
+                                qCatalog.book.author.lastName.eq(carlosCastaneda.getLastName())
+                        )
+                ))
+                .orderBy(qCatalog -> qCatalog.book.id.desc())));
+
+        assertThat(catalogItems, hasSize(2));
+        assertThat(catalogItems.stream().map(catalog -> catalog.getBook().getName()).collect(toList()),
+                contains("Ruslan and Ludmila", "Journey to Ixtlan"));
     }
 
     @Test(groups = "positive tests")
@@ -148,12 +199,12 @@ public class SelectByTypedQuery extends BaseDbOperationTest {
     @Test(groups = "positive tests")
     public void selectOneByResultQuery() {
         var row = dataBaseSteps.select(row(Book.class, byJDOResultQuery(QBook.class)
-                .addResultField(qBook -> qBook.author)
-                .addResultField(qBook -> qBook.name)
-                .addResultField(qBook -> qBook.yearOfFinishing.max())
+                .resultField(qBook -> qBook.author)
+                .resultField(qBook -> qBook.name)
+                .resultField(qBook -> qBook.yearOfFinishing.max())
                 .where(qBook -> qBook.yearOfFinishing.lt(1972))
-                .addGroupBy(qBook -> qBook.author)
-                .addOrderBy(qBook -> qBook.id.asc())
+                .groupBy(qBook -> qBook.author)
+                .orderBy(qBook -> qBook.id.asc())
                 .having(qBook -> qBook.id.count().gteq(1))
                 .distinct(true)));
 
@@ -165,12 +216,12 @@ public class SelectByTypedQuery extends BaseDbOperationTest {
     @Test(groups = "positive tests")
     public void selectListByResultQuery() {
         var rows = dataBaseSteps.select(rows(Book.class, byJDOResultQuery(QBook.class)
-                .addResultField(qBook -> qBook.author)
-                .addResultField(qBook -> qBook.name)
-                .addResultField(qBook -> qBook.yearOfFinishing.max())
+                .resultField(qBook -> qBook.author)
+                .resultField(qBook -> qBook.name)
+                .resultField(qBook -> qBook.yearOfFinishing.max())
                 .where(qBook -> qBook.yearOfFinishing.lt(1972))
-                .addGroupBy(qBook -> qBook.author)
-                .addOrderBy(qBook -> qBook.id.asc())
+                .groupBy(qBook -> qBook.author)
+                .orderBy(qBook -> qBook.id.asc())
                 .having(qBook -> qBook.id.count().gteq(1))
                 .distinct(true)));
 


### PR DESCRIPTION
- improved inconvenience of complex jdo where-expressions. New class WhereJunction
- removed redundant `setOrderBy`, `setGroupBy` and `setResultField`
- `addOrderBy` renamed to `orderBy`
- `addGroupBy` renamed to `groupBy`
- `addResultField` renamed to `resultField`

#133 

...

### By JDO Typed queries

- Select a single persistent object:

```java
...
import static ru.tinkoff.qa.neptune.data.base.api.queries.SelectASingle.oneOf;
import static ru.tinkoff.qa.neptune.data.base.api.queries.jdoql.JDOQLQueryParameters.byJDOQuery;
...

dataBaseSteps.select(oneOf(Author.class, byJDOQuery(QAuthor.class)
        .where(qAuthor -> qAuthor.firstName.eq("Carlos").and(qAuthor.lastName.eq("Castaneda")))
        .orderBy(qAuthor -> qAuthor.id.asc()) //where and order by clauses are supported
        .range(0, 100))
        .criteria("Criteria one", author -> ...)//criteria if query is not
        .criteria(XOR,"Criteria two", author -> ...) //enough/convenient to get 
        // desired object
        .timeOut(ofSeconds(30))//time if where is no such object right now,
        .pollingInterval(ofMillis(500))//between to attempts to get value
        .throwWhenResultEmpty("Some exception message"));//when it is necessary to throw
        // exception on empty result
```

- Select a list of persistent objects:

```java
...
import static ru.tinkoff.qa.neptune.data.base.api.queries.SelectList.listOf;
import static ru.tinkoff.qa.neptune.data.base.api.queries.jdoql.JDOQLQueryParameters.byJDOQuery;
...

dataBaseSteps.select(listOf(Author.class, byJDOQuery(QAuthor.class)
       .where(qAuthor -> qAuthor.firstName.eq("Carlos").and(qAuthor.lastName.eq("Castaneda")))
       .orderBy(qAuthor -> qAuthor.id.asc()) //where and order by clauses are supported
       .range(0, 100))
       .criteria("Criteria one", author -> ...)//criteria if query is not
       .criteria(XOR,"Criteria two", author -> ...) //enough/convenient to get
       // desired objects
       .timeOut(ofSeconds(30))//time if where is no such objects right now,
       .pollingInterval(ofMillis(500))//between to attempts to get value
       .throwWhenResultEmpty("Some exception message"));//when it is necessary to throw
       // exception on empty result
```

To simplify `where`-clause it is possible 

```java
//both expressions are junctioned with AND
carlosCastaneda = dataBaseSteps.select(oneOf(Author.class, byJDOQuery(QAuthor.class)
           .where(qAuthor -> qAuthor.firstName.eq("Carlos"),
                    qAuthor ->  qAuthor.lastName.eq("Castaneda"))));
```

```java
import static  ru.tinkoff.qa.neptune.data.base.api.queries.jdoql.WhereJunction.or;
...

//both expressions are junctioned with OR
var catalogItems = dataBaseSteps.select(listOf(Catalog.class, byJDOQuery(QCatalog.class)
            .where(qCatalog -> or(
                    qCatalog.book.name.eq(ruslanAndLudmila.getName()),
                    qCatalog.book.author.lastName.eq(carlosCastaneda.getLastName()))
            )));
```

```java
import static ru.tinkoff.qa.neptune.data.base.api.queries.jdoql.WhereJunction.and;
import static  ru.tinkoff.qa.neptune.data.base.api.queries.jdoql.WhereJunction.or;
...

var catalogItem = dataBaseSteps.select(oneOf(Catalog.class, byJDOQuery(QCatalog.class)
            //both expressions are junctioned with OR
            .where(qCatalog -> or(
                   and( //these expressions are junctioned with AND
                           qCatalog.book.name.eq(ruslanAndLudmila.getName()),
                           qCatalog.book.author.lastName.eq(alexanderPushkin.getLastName())
                   ),
                   and(
                           qCatalog.book.name.eq(journeyToIxtlan.getName()),
                           qCatalog.book.author.lastName.eq(carlosCastaneda.getLastName())
                   )
            ),// expressions are junctioned with AND by default
           qCatalog -> ... )));
```
Same things work the same way with the selecting of data rows. See below.

- Select a single row of data retrieved from fields of persistent object (new feature):

```java
...
import static ru.tinkoff.qa.neptune.data.base.api.queries.SelectASingle.row;
import static ru.tinkoff.qa.neptune.data.base.api.queries.jdoql.JDOQLResultQueryParams.byJDOResultQuery;
import static ru.tinkoff.qa.neptune.data.base.api.queries.jdoql.WhereJunction.and;
import static  ru.tinkoff.qa.neptune.data.base.api.queries.jdoql.WhereJunction.or;
...

dataBaseSteps.select(row(Book.class, byJDOResultQuery(QBook.class)
       .resultField(qBook -> qBook.author)
       .resultField(qBook -> qBook.name) //it is necessary to define result fields here
       .resultField(qBook -> qBook.yearOfFinishing.max())
       .where(qBook -> qBook.yearOfFinishing.lt(1972))//where and order by clauses are supported
       .groupBy(qBook -> qBook.author)//also supported group by
       .orderBy(qBook -> qBook.id.asc())
       .having(qBook -> qBook.id.count().gteq(1))//and having
       .distinct(true))//when it is necessary to retrieve distinct rows
       .criteria("Criteria one", objects -> ...) //criteria if query is not
       .criteria(XOR,"Criteria two", objects -> ...) //enough/convenient to get
       //desired row
       .timeOut(ofSeconds(30))//time if where is no such object right now,
       .pollingInterval(ofMillis(500))//between to attempts to get value
       .throwWhenResultEmpty("Some exception message"));//when it is necessary to throw
       // exception on empty result
```

It is sumilar to the selecting of raw data by sql, but it looks like it is query to the mapping class. Result is not a raw last of values selected from the datastore directly. Resulted list/row contains values retrieved from an object of the mapping class.

The result of such query see below: 

![Безымянный](https://user-images.githubusercontent.com/4927589/67932771-9650e300-fbd5-11e9-9b98-8d9ef77e2ef0.png)

- Select a rows of data retrieved from fields of persistent objects:

It is similar to the sample above. Result is a list of lists. Each list item contains fields values retrieved from found persistent objects.

```java
...
import static ru.tinkoff.qa.neptune.data.base.api.queries.SelectList.rows;
import static ru.tinkoff.qa.neptune.data.base.api.queries.jdoql.JDOQLResultQueryParams.byJDOResultQuery;
import static ru.tinkoff.qa.neptune.data.base.api.queries.jdoql.WhereJunction.and;
import static  ru.tinkoff.qa.neptune.data.base.api.queries.jdoql.WhereJunction.or;
...

dataBaseSteps.select(rows(Book.class, byJDOResultQuery(QBook.class)
       .resultField(qBook -> qBook.author)
       .resultField(qBook -> qBook.name) //it is necessary to define result fields here
       .resultField(qBook -> qBook.yearOfFinishing.max())
       .where(qBook -> qBook.yearOfFinishing.lt(1972))//where and order by clauses are supported
       .groupBy(qBook -> qBook.author)//also supported group by
       .orderBy(qBook -> qBook.id.asc())
       .having(qBook -> qBook.id.count().gteq(1))//and having
       .distinct(true))//when it is necessary to retrieve distinct rows
       .criteria("Criteria one", objects -> true) //criteria if query is not
       .criteria(XOR,"Criteria two", objects -> true) //enough/convenient to get
       //desired rows
       .timeOut(ofSeconds(30))//time if where is no such objects right now,
       .pollingInterval(ofMillis(500))//between to attempts to get value
       .throwWhenResultEmpty("Some exception message"));//when it is necessary to throw
       // exception on empty result
```

Proposed:
- re-designed code
- additional unit tests

